### PR TITLE
[MER-336] Associate Projects and Products to Community

### DIFF
--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -26,6 +26,8 @@ defmodule Oli.Authoring.Course.Project do
     many_to_many :part_component_registrations, Oli.PartComponents.PartComponentRegistration,
       join_through: Oli.PartComponents.PartComponentRegistrationProject
 
+    many_to_many :communities, Oli.Groups.Community, join_through: Oli.Groups.CommunityVisibility
+
     has_many :publications, Oli.Publishing.Publication
 
     field :owner_id, :integer, virtual: true

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -78,6 +78,8 @@ defmodule Oli.Delivery.Sections.Section do
     field(:total_count, :integer, virtual: true)
     field(:institution_name, :string, virtual: true)
 
+    many_to_many :communities, Oli.Groups.Community, join_through: Oli.Groups.CommunityVisibility
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli/groups/community.ex
+++ b/lib/oli/groups/community.ex
@@ -13,6 +13,13 @@ defmodule Oli.Groups.Community do
 
     many_to_many :authors, Oli.Accounts.Author, join_through: Oli.Groups.CommunityAccount
 
+    many_to_many :projects, Oli.Authoring.Course.Project,
+      join_through: Oli.Groups.CommunityVisibility
+
+    many_to_many :sections, Oli.Delivery.Sections.Section,
+      join_through: Oli.Groups.CommunityVisibility,
+      where: [type: {:fragment, "? = 'blueprint'"}]
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli/groups/community_visibility.ex
+++ b/lib/oli/groups/community_visibility.ex
@@ -1,0 +1,23 @@
+defmodule Oli.Groups.CommunityVisibility do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "communities_visibilities" do
+    belongs_to :community, Oli.Groups.Community
+    belongs_to :project, Oli.Authoring.Course.Project
+    belongs_to :section, Oli.Delivery.Sections.Section
+
+    field :unique_type, :string, virtual: true
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(community_visibility, attrs \\ %{}) do
+    community_visibility
+    |> cast(attrs, [:community_id, :project_id, :section_id])
+    |> validate_required([:community_id])
+    |> unique_constraint([:community_id, :project_id], name: :index_community_project)
+    |> unique_constraint([:community_id, :section_id], name: :index_community_section)
+  end
+end

--- a/lib/oli_web/live/community_live/associated/index_view.ex
+++ b/lib/oli_web/live/community_live/associated/index_view.ex
@@ -1,0 +1,114 @@
+defmodule OliWeb.CommunityLive.Associated.IndexView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.SortableTable.TableHandlers
+
+  alias Oli.Groups
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.CommunityLive.ShowView
+  alias OliWeb.CommunityLive.Associated.{NewView, TableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Surface.Components.Link
+
+  data title, :string, default: "Community Associated"
+  data breadcrumbs, :any
+
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, query, _filter) do
+    Enum.filter(socket.assigns.associations, fn a ->
+      String.contains?(String.downcase(TableModel.get_field(:title, a)), String.downcase(query))
+    end)
+  end
+
+  def live_path(socket, params) do
+    Routes.live_path(socket, __MODULE__, socket.assigns.community_id, params)
+  end
+
+  def breadcrumb(community_id) do
+    ShowView.breadcrumb(community_id) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Associated",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, community_id)
+        })
+      ]
+  end
+
+  def mount(%{"community_id" => community_id}, _session, socket) do
+    associations = Groups.list_community_visibilities(community_id)
+    {:ok, table_model} = TableModel.new(associations, :id, "remove")
+
+    {:ok,
+     assign(socket,
+       breadcrumbs: breadcrumb(community_id),
+       associations: associations,
+       community_id: community_id,
+       table_model: table_model,
+       total_count: length(associations)
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="d-flex p-3 justify-content-between">
+        <Filter
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query}/>
+
+        <Link class="btn btn-primary" to={Routes.live_path(@socket, NewView, @community_id)}>
+          Add new +
+        </Link>
+      </div>
+
+      <div id="projects-products-table" class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={false}
+          additional_table_class=""/>
+      </div>
+    """
+  end
+
+  def handle_event("remove", %{"id" => id}, socket) do
+    clear_flash(socket)
+
+    case Groups.delete_community_visibility(id) do
+      {:ok, _community_visibility} ->
+        socket = put_flash(socket, :info, "Association successfully removed.")
+
+        associations = Groups.list_community_visibilities(socket.assigns.community_id)
+        {:ok, table_model} = TableModel.new(associations, :id, "remove")
+
+        {:noreply,
+         assign(socket,
+           associations: associations,
+           table_model: table_model,
+           total_count: length(associations)
+         )}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Coludn't remove association."
+         )}
+    end
+  end
+end

--- a/lib/oli_web/live/community_live/associated/new_view.ex
+++ b/lib/oli_web/live/community_live/associated/new_view.ex
@@ -1,0 +1,129 @@
+defmodule OliWeb.CommunityLive.Associated.NewView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.SortableTable.TableHandlers
+
+  alias Oli.Authoring.Course
+  alias Oli.Groups
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.CommunityLive.Associated.{IndexView, TableModel}
+  alias Oli.Delivery.Sections.Blueprint
+  alias OliWeb.Router.Helpers, as: Routes
+
+  data title, :string, default: "Community Associate New"
+  data breadcrumbs, :any
+
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, query, _filter) do
+    Enum.filter(socket.assigns.sources, fn a ->
+      String.contains?(String.downcase(TableModel.get_field(:title, a)), String.downcase(query))
+    end)
+  end
+
+  def live_path(socket, params) do
+    Routes.live_path(socket, __MODULE__, socket.assigns.community_id, params)
+  end
+
+  def breadcrumb(community_id) do
+    IndexView.breadcrumb(community_id) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "New",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, community_id)
+        })
+      ]
+  end
+
+  defp retrieve_all_sources() do
+    (Course.list_projects() ++ Blueprint.list())
+    |> Enum.with_index(fn element, index ->
+      type =
+        case Map.has_key?(element, :type) and Map.get(element, :type) == :blueprint do
+          true -> "product"
+          _ -> "project"
+        end
+
+      Map.merge(element, %{
+        unique_type: type,
+        unique_id: index
+      })
+    end)
+  end
+
+  def mount(%{"community_id" => community_id}, _session, socket) do
+    sources = retrieve_all_sources()
+    {:ok, table_model} = TableModel.new(sources)
+
+    {:ok,
+     assign(socket,
+       breadcrumbs: breadcrumb(community_id),
+       sources: sources,
+       table_model: table_model,
+       total_count: length(sources),
+       community_id: community_id
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="p-3">
+        <Filter
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query}/>
+      </div>
+
+      <div id="projects-products-table" class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={false}
+          additional_table_class=""/>
+      </div>
+    """
+  end
+
+  def handle_event("select", %{"id" => id, "type" => type}, socket) do
+    clear_flash(socket)
+
+    attrs =
+      Map.merge(
+        %{
+          community_id: socket.assigns.community_id
+        },
+        case type do
+          "product" -> %{section_id: id}
+          "project" -> %{project_id: id}
+        end
+      )
+
+    socket =
+      case Groups.create_community_visibility(attrs) do
+        {:ok, _community_visibility} ->
+          put_flash(socket, :info, "Association to #{type} succesfully added.")
+
+        {:error, %Ecto.Changeset{}} ->
+          put_flash(
+            socket,
+            :error,
+            "Couldn't associate #{type}. Already exists or an unexpected error ocurred."
+          )
+      end
+
+    {:noreply, socket}
+  end
+end

--- a/lib/oli_web/live/community_live/associated/table_model.ex
+++ b/lib/oli_web/live/community_live/associated/table_model.ex
@@ -1,0 +1,94 @@
+defmodule OliWeb.CommunityLive.Associated.TableModel do
+  use Surface.LiveComponent
+
+  alias Oli.Groups.CommunityVisibility
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def get_field(field, association) do
+    case association do
+      %CommunityVisibility{project: project, section: nil} -> Map.get(project, field)
+      %CommunityVisibility{project: nil, section: section} -> Map.get(section, field)
+      association -> Map.get(association, field)
+    end
+  end
+
+  def new(associations, id_field \\ :unique_id, action \\ "select") do
+    action =
+      case action do
+        "select" -> &__MODULE__.render_select_column/3
+        "remove" -> &__MODULE__.render_remove_column/3
+      end
+
+    SortableTableModel.new(
+      rows: associations,
+      column_specs: [
+        %ColumnSpec{
+          name: :title,
+          label: "Title",
+          render_fn: &__MODULE__.render_title_column/3,
+          sort_fn: &__MODULE__.sort_title_column/2
+        },
+        %ColumnSpec{
+          name: :type,
+          label: "Type",
+          render_fn: &__MODULE__.render_type_column/3
+        },
+        %ColumnSpec{
+          name: :inserted_at,
+          label: "Created",
+          render_fn: &SortableTableModel.render_date_column/3
+        },
+        %ColumnSpec{
+          name: :action,
+          label: "Action",
+          render_fn: action
+        }
+      ],
+      event_suffix: "",
+      id_field: [id_field]
+    )
+  end
+
+  def render_title_column(assigns, item, _) do
+    case item.unique_type do
+      "product" ->
+        route_path =
+          Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, get_field(:slug, item))
+
+        SortableTableModel.render_link_column(assigns, get_field(:title, item), route_path)
+
+      "project" ->
+        route_path = Routes.project_path(OliWeb.Endpoint, :overview, get_field(:slug, item))
+        SortableTableModel.render_link_column(assigns, get_field(:title, item), route_path)
+    end
+  end
+
+  def sort_title_column(sort_order, _sort_spec),
+    do: {fn t -> get_field(:title, t) end, sort_order}
+
+  def render_select_column(assigns, item, _) do
+    ~F"""
+      <button class="btn btn-primary" phx-click="select" phx-value-type={item.unique_type} phx-value-id={item.id}>Select</button>
+    """
+  end
+
+  def render_remove_column(assigns, item, _) do
+    ~F"""
+      <button class="btn btn-primary" phx-click="remove" phx-value-id={item.id}>Remove</button>
+    """
+  end
+
+  def render_type_column(_, item, _) do
+    case item.unique_type do
+      "product" -> "Product"
+      "project" -> "Course Project"
+    end
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -4,6 +4,8 @@ defmodule OliWeb.CommunityLive.ShowView do
 
   alias Oli.Groups
   alias OliWeb.Common.{Breadcrumb, DeleteModal}
+  alias OliWeb.CommunityLive.Associated.IndexView, as: IndexAssociated
+  alias Surface.Components.Link
 
   alias OliWeb.CommunityLive.{
     Form,
@@ -52,7 +54,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             community: community,
             changeset: changeset,
             breadcrumbs: breadcrumb(community_id),
-            community_admins: community_admins
+            community_admins: community_admins,
+            community_id: community_id
           )
       end
 
@@ -77,6 +80,15 @@ defmodule OliWeb.CommunityLive.ShowView do
             placeholder="admin@example.edu"
             button_text="Add"
             collaborators={@community_admins}/>
+        </ShowSection>
+
+        <ShowSection
+          section_title="Projects and Products"
+          section_description="Make selected Projects and Products available to members of this Community."
+        >
+          <Link class="btn btn-link" to={Routes.live_path(@socket, IndexAssociated, @community_id)}>
+            See associated
+          </Link>
         </ShowSection>
 
         <ShowSection section_title="Actions">

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -276,6 +276,11 @@ defmodule OliWeb.Router do
         pipe_through [:authorize_community]
 
         live("/", CommunityLive.ShowView)
+
+        scope "/associated" do
+          live("/", CommunityLive.Associated.IndexView)
+          live("/new", CommunityLive.Associated.NewView)
+        end
       end
     end
   end

--- a/priv/repo/migrations/20211115144220_create_communities_visibilities.exs
+++ b/priv/repo/migrations/20211115144220_create_communities_visibilities.exs
@@ -1,0 +1,16 @@
+defmodule Oli.Repo.Migrations.CreateCommunitiesVisibilities do
+  use Ecto.Migration
+
+  def change do
+    create table(:communities_visibilities) do
+      add :community_id, references(:communities, on_delete: :delete_all)
+      add :project_id, references(:projects, on_delete: :delete_all)
+      add :section_id, references(:sections, on_delete: :delete_all)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create unique_index(:communities_visibilities, [:community_id, :project_id], name: :index_community_project)
+    create unique_index(:communities_visibilities, [:community_id, :section_id], name: :index_community_section)
+  end
+end

--- a/test/oli/groups_test.exs
+++ b/test/oli/groups_test.exs
@@ -232,4 +232,77 @@ defmodule Oli.GroupsTest do
                    end
     end
   end
+
+  describe "community visibility" do
+    alias Oli.Groups.CommunityVisibility
+
+    test "create_community_visibility/1 with valid data creates a community account" do
+      params = params_for(:community_visibility)
+
+      assert {:ok, %CommunityVisibility{} = community_visibility} =
+               Groups.create_community_visibility(params)
+
+      assert community_visibility.project_id == params.project_id
+      assert community_visibility.community_id == params.community_id
+    end
+
+    test "create_community_visibility/1 for existing project and community returns error changeset" do
+      project = build(:project)
+      community = build(:community)
+      insert(:community_visibility, %{project: project, community: community})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Groups.create_community_visibility(%{project: project, community: community})
+    end
+
+    test "get_community_visibility/1 returns a community visibility when the id exists" do
+      community_visibility = insert(:community_visibility)
+
+      returned_community_visibility = Groups.get_community_visibility(community_visibility.id)
+
+      assert community_visibility.id == returned_community_visibility.id
+      assert community_visibility.project_id == returned_community_visibility.project_id
+      assert community_visibility.community_id == returned_community_visibility.community_id
+    end
+
+    test "get_community_visibility/1 returns nil if the community visibility does not exist" do
+      assert nil == Groups.get_community_visibility(123)
+    end
+
+    test "delete_community_visibility/1 deletes the community visibility" do
+      community_visibility = insert(:community_visibility)
+
+      assert {:ok, %CommunityVisibility{}} =
+               Groups.delete_community_visibility(community_visibility.id)
+
+      refute Groups.get_community_visibility(community_visibility.id)
+    end
+
+    test "delete_community_visibility/1 fails when the community visibility does not exist" do
+      community_visibility = insert(:community_visibility)
+
+      assert {:error, :not_found} = Groups.delete_community_visibility(12345)
+
+      assert Groups.get_community_visibility(community_visibility.id)
+    end
+
+    test "list_community_visibilities/1 returns the communities visibilities for a community" do
+      community = insert(:community)
+      insert(:community_visibility, %{community: community})
+      insert(:community_visibility, %{community: community})
+
+      communities_visibilities = Groups.list_community_visibilities(community.id)
+
+      assert [%CommunityVisibility{} | _tail] = communities_visibilities
+      assert 2 = length(communities_visibilities)
+    end
+
+    test "list_community_visibilities/1 returns empty when the community doesn't have any associated" do
+      community = insert(:community)
+
+      communities_visibilities = Groups.list_community_visibilities(community.id)
+
+      assert [] = communities_visibilities
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,7 +2,10 @@ defmodule Oli.Factory do
   use ExMachina.Ecto, repo: Oli.Repo
 
   alias Oli.Accounts.{Author, User}
-  alias Oli.Groups.{Community, CommunityAccount}
+  alias Oli.Authoring.Course.{Family, Project}
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Groups.{Community, CommunityAccount, CommunityVisibility}
+  alias Oli.Institutions.Institution
 
   def author_factory() do
     %Author{
@@ -40,6 +43,54 @@ defmodule Oli.Factory do
       author: insert(:author),
       user: insert(:user),
       is_admin: true
+    }
+  end
+
+  def community_visibility_factory() do
+    %CommunityVisibility{
+      community: insert(:community),
+      project: insert(:project),
+      section: nil
+    }
+  end
+
+  def project_factory() do
+    %Project{
+      description: "Example description",
+      title: "Example Course",
+      slug: sequence("examplecourse"),
+      version: "1",
+      family: insert(:family)
+    }
+  end
+
+  def family_factory() do
+    %Family{
+      description: "Family description",
+      title: "Family title"
+    }
+  end
+
+  def section_factory() do
+    %Section{
+      title: "Section",
+      timezone: "America/New_York",
+      registration_open: true,
+      context_id: UUID.uuid4(),
+      institution: insert(:institution),
+      base_project: insert(:project),
+      slug: sequence("examplesection"),
+      type: :blueprint
+    }
+  end
+
+  def institution_factory() do
+    %Institution{
+      name: "Example Institution",
+      country_code: "US",
+      institution_email: "ins@example.edu",
+      institution_url: "example.edu",
+      timezone: "America/New_York"
     }
   end
 end


### PR DESCRIPTION
Story: https://eliterate.atlassian.net/browse/MER-336

Adds the ability to add and remove associations between communities and projects/products.

- Implements a `many_to_many` within the join table `communities_visibilities`
- Add an index view for the projects/products associated with the community with an action column to remove any of them
- Add an index view for all the projects/products of the system with an action column to add any of them to the community
- The table model is shared between the two indexes, so it supports communities visibilities that have the project or product loaded, or a mixed list of projects and products