### PR TITLE
MER-312 Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Bug Fixes
 
+### Enhancements
+
+## 0.17.0 (2021-11-30)
+
+### Bug Fixes
+
 - Add student input parsing to show student responses in datashop export
 
 ### Enhancements

--- a/assets/src/adaptivity/operators/contains.ts
+++ b/assets/src/adaptivity/operators/contains.ts
@@ -15,7 +15,9 @@ const handleContainsOperator = (
     if (!isString(value)) {
       // use case: factValue = 'abc' and value = ['abc',' abc']
       if (Array.isArray(value)) {
-        return value.some((item: any) => item.trim() === factValue.trim());
+        return value.some((item: any) => {
+          return factValue.trim().includes(item.trim());
+        });
       }
       return false;
     }

--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -23,7 +23,7 @@ export const isEqual = (factValue: any, value: any): boolean => {
   }
   if (Array.isArray(factValue)) {
     let compareValue = value;
-    const updatedFactValue = parseArray(factValue);
+    const updatedFactValue: any = parseArray(factValue);
     let updatedValue = value;
     //Need to parse before we check "if" condition else it will fail for cases where value = '[0,0]'.
     if (!Array.isArray(value) && typeOfValue === 'number') {
@@ -39,6 +39,10 @@ export const isEqual = (factValue: any, value: any): boolean => {
     // ** DT - Sorting both arrays. depending upon user selection in UI the array sometimes comes
     // ** like factValue=[2,5] and value = [5,2] which is right selection but it evaluates to false*/
     updatedFactValue.sort();
+    //compareValue = [] & updatedFactValue = ['']
+    if (compareValue.toString() === updatedFactValue.toString()) {
+      return true;
+    }
     return JSON.stringify(updatedFactValue) === JSON.stringify(compareValue);
   }
   // for boolean values,  factValue comes as true and value comes as 'true'

--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -1,7 +1,7 @@
-import { isFirefox } from 'utils/browser';
 import React, { useEffect, useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 import { Provider, useDispatch, useSelector } from 'react-redux';
+import { isFirefox } from 'utils/browser';
 import { BottomPanel } from './BottomPanel';
 import { AdaptivityEditor } from './components/AdaptivityEditor/AdaptivityEditor';
 import { InitStateEditor } from './components/AdaptivityEditor/InitStateEditor';
@@ -11,16 +11,17 @@ import LeftMenu from './components/LeftMenu/LeftMenu';
 import RightMenu from './components/RightMenu/RightMenu';
 import { SidePanel } from './components/SidePanel';
 import store from './store';
-import { acquireEditingLock, releaseEditingLock } from './store/app/actions/locking';
+import { releaseEditingLock } from './store/app/actions/locking';
+import { attemptDisableReadOnly } from './store/app/actions/readonly';
 import {
   selectBottomPanel,
   selectCurrentRule,
   selectHasEditingLock,
   selectLeftPanel,
   selectProjectSlug,
+  selectReadOnly,
   selectRevisionSlug,
   selectRightPanel,
-  selectshowEditingLockErrMsg,
   selectTopPanel,
   setInitialConfig,
   setPanelState,
@@ -41,14 +42,31 @@ export interface AuthoringProps {
 
 const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const dispatch = useDispatch();
-  const requestEditLock = async () => await dispatch(acquireEditingLock());
 
   const authoringContainer = document.getElementById('advanced-authoring');
   const [isAppVisible, setIsAppVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const hasEditingLock = useSelector(selectHasEditingLock);
-  const showEditingLockErrMsg = useSelector(selectshowEditingLockErrMsg);
+  const isReadOnly = useSelector(selectReadOnly);
+  const [isReadOnlyWarningDismissed, setIsReadOnlyWarningDismissed] = useState(false);
+  const [isAttemptDisableReadOnlyFailed, setIsAttemptDisableReadOnlyFailed] = useState(false);
+
+  const shouldShowLockError = !hasEditingLock && !isReadOnly;
+  const shouldShowReadOnlyWarning = !isLoading && isReadOnly && !isReadOnlyWarningDismissed;
+  const shouldShowEditor =
+    !isLoading && (hasEditingLock || isReadOnly) && !shouldShowReadOnlyWarning;
+
+  const alertSeverity = isAttemptDisableReadOnlyFailed || shouldShowLockError ? 'warning' : 'info';
+
+  /* console.log('RENDER IT', {
+    shouldShowEditor,
+    shouldShowLockError,
+    shouldShowReadOnlyWarning,
+    isAppVisible,
+    hasEditingLock,
+  }); */
+
   const projectSlug = useSelector(selectProjectSlug);
   const revisionSlug = useSelector(selectRevisionSlug);
   const currentRule = useSelector(selectCurrentRule);
@@ -81,6 +99,21 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     dispatch(setPanelState({ top, right, left, bottom }));
   };
 
+  const dismissReadOnlyWarning = async ({ attemptEdit }: { attemptEdit: boolean }) => {
+    if (attemptEdit) {
+      const attemptResult = await dispatch(attemptDisableReadOnly());
+      if ((attemptResult as any).meta.requestStatus !== 'fulfilled') {
+        const errorCode = (attemptResult as any)?.payload?.error;
+        if (errorCode === 'SESSION_EXPIRED') {
+          window.location.reload();
+        }
+        setIsAttemptDisableReadOnlyFailed(true);
+        return;
+      }
+    }
+    setIsReadOnlyWarningDismissed(true);
+  };
+
   useEffect(() => {
     const appConfig = {
       paths: props.paths,
@@ -108,7 +141,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
         authoringContainer?.classList.add('startup');
       }, 50);
     }
-    if (!isAppVisible || !hasEditingLock) {
+    if (!isAppVisible) {
       // reset forced light mode
       const darkModeCss: any = document.getElementById('authoring-theme-dark');
       darkModeCss.href = '/css/authoring_torus_dark.css';
@@ -121,7 +154,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     return () => {
       document.body.classList.remove('overflow-hidden');
     };
-  }, [isAppVisible, hasEditingLock]);
+  }, [isAppVisible]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', async () =>
@@ -133,7 +166,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     );
 
     setTimeout(() => {
-      if (hasEditingLock) {
+      if (hasEditingLock || (isReadOnly && isReadOnlyWarningDismissed)) {
         setIsAppVisible(true);
       }
     }, 500);
@@ -144,11 +177,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     return () => {
       window.removeEventListener('beforeunload', async () => await dispatch(releaseEditingLock()));
     };
-  }, [hasEditingLock]);
-
-  useEffect(() => {
-    requestEditLock();
-  }, []);
+  }, [hasEditingLock, isReadOnly, isReadOnlyWarningDismissed]);
 
   return (
     <>
@@ -159,7 +188,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
           </div>
         </div>
       )}
-      {hasEditingLock && (
+      {shouldShowEditor && (
         <div id="advanced-authoring" className={`advanced-authoring d-none`}>
           <HeaderNav panelState={panelState} isVisible={panelState.top} />
           <SidePanel
@@ -186,26 +215,52 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
           </SidePanel>
         </div>
       )}
-      {!hasEditingLock && (
-        <Alert variant="warning">
-          <Alert.Heading>
-            {showEditingLockErrMsg ? 'Editing Session Timed Out' : 'Editing In Progress'}
-          </Alert.Heading>
-          <p>
-            {showEditingLockErrMsg
-              ? `Too much time passed since your last edit and now someone else is currently editing this page. `
-              : `Sorry, someone else is currently editing this page. `}
-            You can try refreshing the browser to see if the current editor is done, or you can use
-            the link below to open a preview of the page.
-          </p>
+
+      {shouldShowReadOnlyWarning && (
+        <Alert variant={alertSeverity}>
+          <Alert.Heading>Opening in Read-Only Mode</Alert.Heading>
+          {!isAttemptDisableReadOnlyFailed && (
+            <p>
+              You are about to open this page in read-only mode. You are able to view the contents
+              of this page, but any changes you make will not be saved. You may instead attempt to
+              open in editing mode, or open a preview of the page.
+            </p>
+          )}
+          {isAttemptDisableReadOnlyFailed && (
+            <p>
+              Unfortunately, we were unable to disable read-only mode. Another author currently has
+              the page locked for editing. Please try again later. In the meantime, you may continue
+              in Read Only mode or open a preview of the page.
+            </p>
+          )}
           <hr />
-          <Button
-            variant="outline-warning"
-            className="text-dark"
-            onClick={() => window.open(url, windowName)}
-          >
-            Open Preview <i className="las la-external-link-alt ml-1"></i>
-          </Button>
+          <div style={{ textAlign: 'center' }}>
+            <Button
+              variant={`outline-${alertSeverity}`}
+              className="text-dark"
+              onClick={() => dismissReadOnlyWarning({ attemptEdit: false })}
+            >
+              Continue In Read-Only Mode
+            </Button>{' '}
+            {!isAttemptDisableReadOnlyFailed && (
+              <>
+                <Button
+                  variant={`outline-${alertSeverity}`}
+                  className="text-dark"
+                  onClick={() => dismissReadOnlyWarning({ attemptEdit: true })}
+                >
+                  Open In Edit Mode
+                </Button>{' '}
+              </>
+            )}
+            <Button
+              variant={`outline-${alertSeverity}`}
+              className="text-dark"
+              onClick={() => window.open(url, windowName)}
+            >
+              Open Preview <i className="las la-external-link-alt ml-1"></i>
+            </Button>
+          </div>
         </Alert>
       )}
     </>

--- a/assets/src/apps/authoring/components/HeaderNav.tsx
+++ b/assets/src/apps/authoring/components/HeaderNav.tsx
@@ -2,7 +2,12 @@
 import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
-import { selectPaths, selectProjectSlug, selectRevisionSlug } from '../store/app/slice';
+import {
+  selectPaths,
+  selectProjectSlug,
+  selectReadOnly,
+  selectRevisionSlug,
+} from '../store/app/slice';
 import AddComponentToolbar from './ComponentToolbar/AddComponentToolbar';
 import ComponentSearchContextMenu from './ComponentToolbar/ComponentSearchContextMenu';
 
@@ -16,10 +21,16 @@ const HeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
   const projectSlug = useSelector(selectProjectSlug);
   const revisionSlug = useSelector(selectRevisionSlug);
   const paths = useSelector(selectPaths);
+  const isReadOnly = useSelector(selectReadOnly);
   const PANEL_SIDE_WIDTH = '270px';
 
   const url = `/authoring/project/${projectSlug}/preview/${revisionSlug}`;
   const windowName = `preview-${projectSlug}`;
+
+  const handleReadOnlyClick = () => {
+    // TODO: show a modal offering to confirm if you want to disable read only
+    // but changes that were made will be lost. better right now to just use browser refresh
+  };
 
   return (
     paths && (
@@ -54,21 +65,26 @@ const HeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
                 </button>
               </span>
             </OverlayTrigger>
-            <OverlayTrigger
-              placement="bottom"
-              delay={{ show: 150, hide: 150 }}
-              overlay={
-                <Tooltip id="button-tooltip" style={{ fontSize: '12px' }}>
-                  Publish
-                </Tooltip>
-              }
-            >
-              <span>
-                <button className="px-2 btn btn-link" disabled>
-                  <img src={`${paths.images}/icons/icon-publish.svg`}></img>
-                </button>
-              </span>
-            </OverlayTrigger>
+            {isReadOnly && (
+              <OverlayTrigger
+                placement="bottom"
+                delay={{ show: 150, hide: 150 }}
+                overlay={
+                  <Tooltip id="button-tooltip" style={{ fontSize: '12px' }}>
+                    Read Only
+                  </Tooltip>
+                }
+              >
+                <span>
+                  <button className="px-2 btn btn-link" onClick={handleReadOnlyClick}>
+                    <i
+                      className="fa fa-exclamation-triangle"
+                      style={{ fontSize: 40, color: 'goldenrod' }}
+                    />
+                  </button>
+                </span>
+              </OverlayTrigger>
+            )}
           </div>
         </div>
       </nav>

--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -6,7 +6,7 @@ import {
   IActivity,
   upsertActivity,
 } from '../../../../delivery/store/features/activities/slice';
-import { selectProjectSlug } from '../../app/slice';
+import { selectProjectSlug, selectReadOnly } from '../../app/slice';
 import { selectResourceId } from '../../page/slice';
 
 export const saveActivity = createAsyncThunk(
@@ -17,21 +17,27 @@ export const saveActivity = createAsyncThunk(
     const projectSlug = selectProjectSlug(rootState);
     const resourceId = selectResourceId(rootState);
 
+    const isReadOnlyMode = selectReadOnly(rootState);
+
     const changeData: ActivityUpdate = {
       title: activity.title as string,
       objectives: activity.objectives as ObjectiveMap,
       content: { ...activity.content, authoring: activity.authoring },
       tags: activity.tags,
     };
-    /* console.log('going to save acivity: ', { changeData, activity }); */
-    const editResults = await edit(
-      projectSlug,
-      resourceId,
-      activity.resourceId as number,
-      changeData,
-      false,
-    );
-    /* console.log('EDIT SAVE RESULTS', { editResults }); */
+
+    if (!isReadOnlyMode) {
+      /* console.log('going to save acivity: ', { changeData, activity }); */
+      const editResults = await edit(
+        projectSlug,
+        resourceId,
+        activity.resourceId as number,
+        changeData,
+        false,
+      );
+      /* console.log('EDIT SAVE RESULTS', { editResults }); */
+    }
+
     await dispatch(upsertActivity({ activity }));
     return;
   },

--- a/assets/src/apps/authoring/store/app/actions/readonly.ts
+++ b/assets/src/apps/authoring/store/app/actions/readonly.ts
@@ -1,0 +1,49 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { AppSlice, selectReadOnly, setReadonly } from '../slice';
+import { acquireEditingLock } from './locking';
+
+export const attemptDisableReadOnly = createAsyncThunk(
+  `${AppSlice}/attemptDisableReadOnly`,
+  async (payload, { dispatch, getState, rejectWithValue }) => {
+    const rootState = getState() as any;
+    const isReadOnly = selectReadOnly(rootState);
+
+    if (!isReadOnly) {
+      return rejectWithValue({
+        error: 'ALREADY_DISABLED',
+        msg: 'Cannot disable read-only mode, already disabled.',
+      });
+    }
+
+    try {
+      const lockResult = await dispatch(acquireEditingLock()); // .unwrap();
+      // console.log('attemptDisableReadOnly: lockResult', lockResult);
+      if (lockResult.meta.requestStatus !== 'fulfilled') {
+        let error = 'LOCK_FAILED';
+        const lockErrorCode = (lockResult as any)?.payload?.error;
+        let msg = 'Failed to acquire editing lock.';
+        if (lockErrorCode === 'ALREADY_LOCKED') {
+          msg = (lockResult as any)?.payload?.msg;
+          error = lockErrorCode;
+        }
+        if (lockErrorCode === 'SERVER_ERROR') {
+          msg = (lockResult as any)?.payload?.msg;
+          error = 'SESSION_EXPIRED';
+        }
+        return rejectWithValue({ error, msg });
+      }
+    } catch (error) {
+      return rejectWithValue({
+        error: 'EXCEPTION',
+        exception: error,
+        msg: 'Cannot disable read-only mode, exception',
+      });
+    }
+
+    // console.log('attemptDisableReadOnly: success');
+
+    dispatch(setReadonly({ readonly: false }));
+
+    return;
+  },
+);

--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -44,12 +44,12 @@ export interface AppState {
   bottomPanel: boolean;
   visible: boolean; // temp full screen rocket
   hasEditingLock: boolean;
-  showEditingLockErrMsg: boolean;
   rightPanelActiveTab: RightPanelTabs;
   currentRule: any;
   partComponentTypes: PartComponentRegistration[];
   activityTypes: ActivityRegistration[];
   copiedPart: any | null;
+  readonly: boolean;
 }
 
 const initialState: AppState = {
@@ -63,12 +63,12 @@ const initialState: AppState = {
   bottomPanel: true,
   visible: false,
   hasEditingLock: false,
-  showEditingLockErrMsg: false,
   rightPanelActiveTab: RightPanelTabs.LESSON,
   currentRule: undefined,
   partComponentTypes: [],
   activityTypes: [],
   copiedPart: null,
+  readonly: true,
 };
 
 export interface AppConfig {
@@ -82,7 +82,7 @@ export interface AppConfig {
 }
 
 const slice: Slice<AppState> = createSlice({
-  name: 'app',
+  name: 'mainApp',
   initialState,
   reducers: {
     setInitialConfig(state, action: PayloadAction<AppConfig>) {
@@ -118,9 +118,6 @@ const slice: Slice<AppState> = createSlice({
     setHasEditingLock(state, action: PayloadAction<{ hasEditingLock: boolean }>) {
       state.hasEditingLock = action.payload.hasEditingLock;
     },
-    setShowEditingLockErrMsg(state, action: PayloadAction<{ showEditingLockErrMsg: boolean }>) {
-      state.showEditingLockErrMsg = action.payload.showEditingLockErrMsg;
-    },
     setRightPanelActiveTab(state, action: PayloadAction<{ rightPanelActiveTab: RightPanelTabs }>) {
       state.rightPanelActiveTab = action.payload.rightPanelActiveTab;
     },
@@ -129,6 +126,9 @@ const slice: Slice<AppState> = createSlice({
     },
     setCopiedPart(state, action: PayloadAction<{ copiedPart: any }>) {
       state.copiedPart = action.payload.copiedPart;
+    },
+    setReadonly(state, action: PayloadAction<{ readonly: boolean }>) {
+      state.readonly = action.payload.readonly;
     },
   },
   extraReducers: (builder) => {
@@ -139,19 +139,15 @@ const slice: Slice<AppState> = createSlice({
       state.hasEditingLock = false;
     });
     builder.addCase(savePage.rejected, (state) => {
-      state.showEditingLockErrMsg = true;
       state.hasEditingLock = false;
     });
     builder.addCase(saveActivity.rejected, (state) => {
-      state.showEditingLockErrMsg = true;
       state.hasEditingLock = false;
     });
     builder.addCase(savePartState.rejected, (state) => {
-      state.showEditingLockErrMsg = true;
       state.hasEditingLock = false;
     });
     builder.addCase(savePartStateToTree.rejected, (state) => {
-      state.showEditingLockErrMsg = true;
       state.hasEditingLock = false;
     });
   },
@@ -168,6 +164,7 @@ export const {
   setRightPanelActiveTab,
   setCurrentRule,
   setCopiedPart,
+  setReadonly,
 } = slice.actions;
 
 export const selectState = (state: RootState): AppState => state[AppSlice] as AppState;
@@ -203,10 +200,7 @@ export const selectHasEditingLock = createSelector(
   selectState,
   (state: AppState) => state.hasEditingLock,
 );
-export const selectshowEditingLockErrMsg = createSelector(
-  selectState,
-  (state: AppState) => state.showEditingLockErrMsg,
-);
+
 export const selectPartComponentTypes = createSelector(
   selectState,
   (state: AppState) => state.partComponentTypes,
@@ -216,5 +210,7 @@ export const selectActivityTypes = createSelector(
   selectState,
   (state: AppState) => state.activityTypes,
 );
+
+export const selectReadOnly = createSelector(selectState, (state: AppState) => state.readonly);
 
 export default slice.reducer;

--- a/assets/src/apps/authoring/store/page/actions/savePage.ts
+++ b/assets/src/apps/authoring/store/page/actions/savePage.ts
@@ -3,13 +3,17 @@ import { ResourceContent } from 'data/content/resource';
 import { edit, Edited, ResourceUpdate } from 'data/persistence/resource';
 import { clone } from 'utils/common';
 import { selectAll as selectAllGroups } from '../../../../delivery/store/features/groups/slice';
-import { selectProjectSlug } from '../../app/slice';
+import { selectProjectSlug, selectReadOnly } from '../../app/slice';
 import { RootState } from '../../rootReducer';
 import { PageSlice, PageState, selectRevisionSlug, selectState, setRevisionSlug } from '../slice';
 
 export const savePage = createAsyncThunk(
   `${PageSlice}/savePage`,
   async (payload: Partial<PageState> = {}, { getState, dispatch }) => {
+    const isReadOnlyMode = selectReadOnly(getState() as RootState);
+    if (isReadOnlyMode) {
+      return;
+    }
     const projectSlug = selectProjectSlug(getState() as RootState);
     const revisionSlug = selectRevisionSlug(getState() as RootState);
     const currentPage = selectState(getState() as RootState);

--- a/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
+++ b/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
@@ -21,28 +21,14 @@ type DeliveryProps = PartComponentProps<CustomProperties>;
 
 const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
   const pusherContext = useContext(NotificationContext);
-
-  let height = props.model.height;
-  // TODO: figure out how to default TF *only* to height auto without hard coding type
-  if (props.type === 'janus-mcq') {
-    if (!props.model.overrideHeight) {
-      height = 'auto';
-    }
-  }
   const initialStyles: CSSProperties = {
     display: 'block',
     position: 'absolute',
     top: props.model.y,
     left: props.model.x,
     zIndex: props.model.z || 0,
-    width: props.model.width,
   };
-  if (
-    props.type !== 'janus-text-flow' ||
-    (props.type === 'janus-text-flow' && props.model.overrideHeight)
-  ) {
-    initialStyles.height = height;
-  }
+
   const [componentStyle, setComponentStyle] = useState<CSSProperties>(initialStyles);
 
   const [customCssClass, setCustomCssClass] = useState<string>(props.model.customCssClass || '');
@@ -93,22 +79,12 @@ const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
       const settings = payload.settings;
       const styleChanges: CSSProperties = {};
 
-      if (componentStyle.width && settings?.width) {
-        const newW = settings.width.value;
-        if (settings.width.type === 'relative') {
-          styleChanges.width = parseFloat(componentStyle.width.toString()) + newW;
-        } else {
-          styleChanges.width = newW;
-        }
+      if (settings?.width) {
+        styleChanges.width = settings.width.value;
       }
 
-      if (componentStyle.height && settings?.height) {
-        const newH = settings.height.value;
-        if (settings.height.type === 'relative') {
-          styleChanges.height = parseFloat(componentStyle.height.toString()) + newH;
-        } else {
-          styleChanges.height = newH;
-        }
+      if (settings?.height) {
+        styleChanges.height = settings.height.value;
       }
 
       if (settings?.zIndex) {

--- a/assets/src/components/parts/janus-Carousel/Carousel.tsx
+++ b/assets/src/components/parts/janus-Carousel/Carousel.tsx
@@ -31,6 +31,17 @@ const Carousel: React.FC<PartComponentProps<CarouselModel>> = (props) => {
   // initialize the swiper
   SwiperCore.use([Navigation, Pagination, A11y, Keyboard, Zoom]);
 
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
+
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dZoom = typeof pModel.zoom === 'boolean' ? pModel.zoom : carouselZoom;
@@ -75,7 +86,7 @@ const Carousel: React.FC<PartComponentProps<CarouselModel>> = (props) => {
     if (sCurrentImage !== undefined) {
       setCurrentSlide(sCurrentImage);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-audio/Audio.tsx
+++ b/assets/src/components/parts/janus-audio/Audio.tsx
@@ -16,6 +16,17 @@ const Audio: React.FC<PartComponentProps<AudioModel>> = (props) => {
   const [showControls, setShowControls] = useState(true);
   const [classes, setClasses] = useState<any>('');
 
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
+
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dCssClass = pModel.customCssClass || classes;
@@ -76,7 +87,7 @@ const Audio: React.FC<PartComponentProps<AudioModel>> = (props) => {
     if (sEnableReplay !== undefined) {
       setAudioEnableReplay(sEnableReplay);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
@@ -21,7 +21,6 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
   const [configClicked, setconfigClicked] = useState(false);
   const [ready, setReady] = useState<boolean>(false);
   const [internalState, setInternalState] = useState<any>([]);
-  const [isCAPI, setIsCAPI] = useState<boolean>(false);
 
   const styles: CSSProperties = {
     width,
@@ -105,10 +104,6 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
   }, []);
 
   useEffect(() => {
-    setIsCAPI(false);
-  }, [props.model.src]);
-
-  useEffect(() => {
     // all activities *must* emit onReady
     props.onReady({ id: `${props.id}` });
   }, [ready]);
@@ -135,7 +130,6 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
   };
 
   const handleHandshakeRequest = (msgData: CapiMessage) => {
-    setIsCAPI(true);
     const {
       handshake: { requestToken: msgRequestToken },
     } = msgData;
@@ -406,7 +400,7 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
                 <label style={lableStyles}>{props.id}</label>
                 {src && !configClicked && (
                   <div style={configDivStyles} className="form-group">
-                    {isCAPI && (
+                    {
                       <a
                         href="#!"
                         onClick={() => setconfigClicked(true)}
@@ -414,12 +408,11 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
                       >
                         configure
                       </a>
-                    )}
+                    }
                     <iframe
                       ref={frameRef}
                       style={{ display: 'none', height: '100%', width: '100%' }}
                       data-janus-type={tagName}
-                      src={props.model.src}
                       scrolling={props.type?.toLowerCase() === 'janus-capi-iframe' ? 'no' : ''}
                     />
                   </div>

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -45,6 +45,17 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [frameCssClass, setFrameCssClass] = useState('');
   // these rely on being set every render and the "model" useState value being set
   const { src, title, allowScrolling, configData } = model;
+  useEffect(() => {
+    const styleChanges: any = {};
+    if (frameWidth !== undefined) {
+      styleChanges.width = { value: frameWidth as number };
+    }
+    if (frameHeight != undefined) {
+      styleChanges.height = { value: frameHeight as number };
+    }
+
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  }, [frameWidth, frameHeight]);
 
   const initialize = useCallback(async (pModel) => {
     // set defaults
@@ -641,46 +652,64 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     }, 150);
   };
 
-  const handleResizeParentContainer = (data: any) => {
-    const iFrameResponse: { key: string; type: number; value: string }[] = [];
-    const modifiedData = data;
-    if (frameWidth && data?.width) {
-      const newW = parseFloat(data.width.value);
-      modifiedData.width.value = newW;
-    }
-    if (frameHeight && data?.height) {
-      const newH = parseFloat(data.height.value);
-      modifiedData.height.value = newH;
-    }
-    if (modifiedData?.height?.value) {
-      iFrameResponse.push({
-        key: `IFRAME_frameHeight`,
-        type: CapiVariableTypes.NUMBER,
-        value: modifiedData?.height?.value || frameHeight,
+  const handleResizeParentContainer = useCallback(
+    (data: any) => {
+      const iFrameResponse: { key: string; type: number; value: string }[] = [];
+      const modifiedData = data;
+      if (data?.width) {
+        setFrameWidth((previousWidth) => {
+          const newW = parseFloat(data.width.value);
+          if (data.width.type === 'relative') {
+            modifiedData.width.value = previousWidth + newW;
+          } else {
+            modifiedData.width.value = newW;
+          }
+          return modifiedData.width.value;
+        });
+      }
+      if (data?.height) {
+        setFrameHeight((previousHeight) => {
+          const newW = parseFloat(data.height.value);
+          if (data.height.type === 'relative') {
+            modifiedData.height.value = previousHeight + newW;
+          } else {
+            modifiedData.height.value = newW;
+          }
+          return modifiedData.height.value;
+        });
+      }
+
+      if (modifiedData?.height?.value) {
+        iFrameResponse.push({
+          key: `IFRAME_frameHeight`,
+          type: CapiVariableTypes.NUMBER,
+          value: modifiedData?.height?.value || frameHeight,
+        });
+      }
+      if (modifiedData?.width?.value) {
+        iFrameResponse.push({
+          key: `IFRAME_frameWidth`,
+          type: CapiVariableTypes.NUMBER,
+          value: modifiedData?.width?.value || frameWidth,
+        });
+      }
+      props.onSave({
+        id,
+        responses: iFrameResponse,
       });
-    }
-    if (modifiedData?.width?.value) {
-      iFrameResponse.push({
-        key: `IFRAME_frameWidth`,
-        type: CapiVariableTypes.NUMBER,
-        value: modifiedData?.width?.value || frameWidth,
-      });
-    }
-    props.onSave({
-      id,
-      responses: iFrameResponse,
-    });
-    props.onResize({ id: `${id}`, settings: modifiedData });
-    sendFormedResponse(
-      simLife.handshake,
-      {},
-      JanusCAPIRequestTypes.RESIZE_PARENT_CONTAINER_RESPONSE,
-      {
-        messageId: data.messageId,
-        responseType: 'success',
-      },
-    );
-  };
+      props.onResize({ id: `${id}`, settings: modifiedData });
+      sendFormedResponse(
+        simLife.handshake,
+        {},
+        JanusCAPIRequestTypes.RESIZE_PARENT_CONTAINER_RESPONSE,
+        {
+          messageId: data.messageId,
+          responseType: 'success',
+        },
+      );
+    },
+    [frameWidth, frameHeight],
+  );
 
   //#endregion
 

--- a/assets/src/components/parts/janus-dropdown/Dropdown.tsx
+++ b/assets/src/components/parts/janus-dropdown/Dropdown.tsx
@@ -21,6 +21,17 @@ const Dropdown: React.FC<PartComponentProps<DropdownModel>> = (props) => {
   const [selectedItem, setSelectedItem] = useState<string>('');
   const [cssClass, setCssClass] = useState('');
 
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
+
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dEnabled = typeof pModel.enabled === 'boolean' ? pModel.enabled : enabled;
@@ -115,6 +126,7 @@ const Dropdown: React.FC<PartComponentProps<DropdownModel>> = (props) => {
     if (initResult.context.mode === contexts.REVIEW) {
       setEnabled(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -97,6 +97,16 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
     borderRadius: '5px',
     fontFamily: 'revert',
   };
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     const partResponses: any[] = pModel?.elements?.map((el: any) => {
       const val: string = getElementValueByKey(el.key);
@@ -151,7 +161,7 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
     if (initResult.context.mode === contexts.REVIEW) {
       setEnabled(false);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-image/Image.tsx
+++ b/assets/src/components/parts/janus-image/Image.tsx
@@ -12,7 +12,16 @@ const Image: React.FC<PartComponentProps<ImageModel>> = (props) => {
   const [model, setModel] = useState<any>(typeof props.model === 'object' ? props.model : {});
   const [ready, setReady] = useState<boolean>(false);
   const id: string = props.id;
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     const initResult = await props.onInit({
       id,
@@ -23,7 +32,7 @@ const Image: React.FC<PartComponentProps<ImageModel>> = (props) => {
       const currentStateSnapshot = initResult.snapshot;
       setState(currentStateSnapshot);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-input-number/InputNumber.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumber.tsx
@@ -70,6 +70,7 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = (props) => {
       setEnabled(false);
     }
     setReady(true);
+    handleStylingChanges();
   }, []);
 
   useEffect(() => {
@@ -196,6 +197,14 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = (props) => {
   };
   const inputNumberCompStyles: CSSProperties = {
     width: '100%',
+  };
+
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width.value = width as number;
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
   };
 
   const debouncetime = 300;

--- a/assets/src/components/parts/janus-input-text/InputText.tsx
+++ b/assets/src/components/parts/janus-input-text/InputText.tsx
@@ -33,7 +33,16 @@ const InputText: React.FC<PartComponentProps<InputTextModel>> = (props) => {
       ],
     });
   };
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dEnabled = typeof pModel.enabled === 'boolean' ? pModel.enabled : enabled;
@@ -90,6 +99,7 @@ const InputText: React.FC<PartComponentProps<InputTextModel>> = (props) => {
     if (initResult.context.mode === contexts.REVIEW) {
       setEnabled(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -652,15 +652,20 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
 
   // will always *replace* the selected choices (used by init & mutate)
   const handleMultipleItemSelection = (selections: ItemSelectionInput[], shouldSave = true) => {
+    let modifiedSelections = selections;
     const newCount = selections.length;
-
-    const newSelectedChoices = selections
+    const blankValueExit =
+      (selections.length === 1 && selections.filter((item) => item.value <= 0)) || [];
+    if (blankValueExit.length) {
+      modifiedSelections = [];
+    }
+    const newSelectedChoices = modifiedSelections
       .sort((a, b) => a.value - b.value)
       .map((item) => item.value);
 
     const newSelectedChoice = newSelectedChoices[0];
 
-    const newSelectedChoicesText = selections
+    const newSelectedChoicesText = modifiedSelections
       .sort((a, b) => a.value - b.value)
       .map((item) => item.textValue);
 
@@ -697,7 +702,7 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
     if (multipleSelection) {
       // sets data for checkboxes, which can have multiple values
       newSelectedChoices = [...new Set([...selectedChoices, newChoice])].filter(
-        (c) => checked || (!checked && originalValue !== c),
+        (c) => checked || (!checked && originalValue !== c && c > 0),
       );
 
       newChoice = newSelectedChoices.sort()[0] || 0;
@@ -705,14 +710,20 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
       updatedChoicesText = newSelectedChoices
         .sort()
         .map((choice) => getOptionTextById(options, choice));
-      updatedChoiceText = updatedChoicesText[0];
+      updatedChoiceText = updatedChoicesText[0] || '';
 
       newCount = newSelectedChoices.length;
     }
-
+    let modifiedNewSelectedChoices = newSelectedChoices;
+    const blankValueExit =
+      (newSelectedChoices.length === 1 && newSelectedChoices.filter((value) => value <= 0)) || [];
+    if (blankValueExit.length) {
+      modifiedNewSelectedChoices = [];
+      updatedChoicesText = [];
+    }
     setNumberOfSelectedChoices(newCount);
     setSelectedChoice(newChoice);
-    setSelectedChoices(newSelectedChoices);
+    setSelectedChoices(modifiedNewSelectedChoices);
     setSelectedChoiceText(updatedChoiceText);
     setSelectedChoicesText(updatedChoicesText);
 
@@ -721,7 +732,7 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
         numberOfSelectedChoices: newCount,
         selectedChoice: newChoice,
         selectedChoiceText: updatedChoiceText,
-        selectedChoices: newSelectedChoices,
+        selectedChoices: modifiedNewSelectedChoices,
         selectedChoicesText: updatedChoicesText,
       });
     }

--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -249,7 +249,20 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
   const [selectedChoiceText, setSelectedChoiceText] = useState<string>('');
   const [selectedChoices, setSelectedChoices] = useState<number[]>([]);
   const [selectedChoicesText, setSelectedChoicesText] = useState<string[]>([]);
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      if (!props.model.overrideHeight) {
+        styleChanges.height = { value: 'auto' };
+      } else {
+        styleChanges.height = { value: height as number };
+      }
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults from model
     const dEnabled = typeof pModel.enabled === 'boolean' ? pModel.enabled : enabled;
@@ -394,6 +407,7 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
     if (initResult.context.mode === contexts.REVIEW) {
       setEnabled(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
+++ b/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
@@ -33,6 +33,16 @@ const MultiLineTextInput: React.FC<PartComponentProps<MultiLineTextModel>> = (pr
       ],
     });
   };
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dEnabled = typeof pModel.enabled === 'boolean' ? pModel.enabled : enabled;
@@ -89,6 +99,7 @@ const MultiLineTextInput: React.FC<PartComponentProps<MultiLineTextModel>> = (pr
     if (initResult.context.mode === contexts.REVIEW) {
       setEnabled(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -39,10 +39,20 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
   if (buttonColor) {
     styles.backgroundColor = buttonColor;
   }
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${props.id}`, settings: styleChanges });
+  };
   useEffect(() => {
     // all activities *must* emit onReady
     props.onReady({ id: `${props.id}` });
+    handleStylingChanges();
   }, []);
 
   const buttonProps = {

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -25,7 +25,16 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
   const [initSnapshot, setInitSnapshot] = useState<InitResultProps>();
 
   const [activityHost, setActivityHost] = useState<any>(null);
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     const initResult = await props.onInit({
       id,
@@ -77,6 +86,7 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
     if (initResult.context.mode === contexts.REVIEW) {
       setContext(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-slider/Slider.tsx
+++ b/assets/src/components/parts/janus-slider/Slider.tsx
@@ -22,7 +22,16 @@ const Slider: React.FC<PartComponentProps<SliderModel>> = (props) => {
   const [sliderValue, setSliderValue] = useState(0);
   const [isSliderEnabled, setIsSliderEnabled] = useState(true);
   const [cssClass, setCssClass] = useState('');
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${props.id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dEnabled = typeof pModel.enabled === 'boolean' ? pModel.enabled : isSliderEnabled;
@@ -79,6 +88,7 @@ const Slider: React.FC<PartComponentProps<SliderModel>> = (props) => {
     if (initResult.context.mode === contexts.REVIEW) {
       setIsSliderEnabled(false);
     }
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-text-flow/Markup.tsx
+++ b/assets/src/components/parts/janus-text-flow/Markup.tsx
@@ -73,7 +73,9 @@ const Markup: React.FC<any> = ({
     // add a non breaking space instead of nothing
 
     processedText = processedText.length < 2 && !processedText.trim() ? '\u00a0' : processedText;
-    renderStyles.visibility = 'hidden';
+    if (tag === 'span') {
+      renderStyles.visibility = 'hidden';
+    }
   }
   if (processedText.length !== processedText.trimLeft().length) {
     const noOfleadingSpaces = processedText.length - processedText.trimLeft().length;

--- a/assets/src/components/parts/janus-text-flow/TextFlow.tsx
+++ b/assets/src/components/parts/janus-text-flow/TextFlow.tsx
@@ -101,6 +101,16 @@ const TextFlow: React.FC<PartComponentProps<TextFlowModel>> = (props: any) => {
   const [scriptEnv, setScriptEnv] = useState<any>();
   const id: string = props.id;
 
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined && props.model.overrideHeight) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults
 
@@ -118,7 +128,7 @@ const TextFlow: React.FC<PartComponentProps<TextFlowModel>> = (props: any) => {
       const flowEnv = new Environment(initResult.env);
       setScriptEnv(flowEnv);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/assets/src/components/parts/janus-text-flow/quill-utils.ts
+++ b/assets/src/components/parts/janus-text-flow/quill-utils.ts
@@ -225,6 +225,9 @@ const processJanusChildren = (node: JanusMarkupNode, doc: Delta, parentAttrs: an
             parentAttrs.list = 'bullet';
           }
           if (child.tag === 'li') {
+            if (index === 0) {
+              doc.insert('\n');
+            }
             lineAttrs.list = parentAttrs.list;
           }
           if (child.style?.textAlign) {
@@ -233,6 +236,7 @@ const processJanusChildren = (node: JanusMarkupNode, doc: Delta, parentAttrs: an
           if (child.tag === 'img') {
             doc.insert({ image: child.src });
           }
+          line.insert('\n', lineAttrs);
         }
       }
       const childLine = processJanusChildren(child, new Delta(), attrs);
@@ -268,6 +272,9 @@ export const convertJanusToQuill = (nodes: JanusMarkupNode[]) => {
           attrs.list = parentAttrs.list;
         }
         if (node.style?.textAlign) {
+          if (index === 1) {
+            doc.insert('\n');
+          }
           attrs.align = node.style.textAlign;
         }
         line.insert('\n', attrs);

--- a/assets/src/components/parts/janus-video/Video.tsx
+++ b/assets/src/components/parts/janus-video/Video.tsx
@@ -20,7 +20,16 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
   const [videoAutoPlay, setVideoAutoPlay] = useState(false);
   const [videoEnableReplay, setVideoEnableReplay] = useState(true);
   const [cssClass, setCssClass] = useState('');
-
+  const handleStylingChanges = () => {
+    const styleChanges: any = {};
+    if (width !== undefined) {
+      styleChanges.width = { value: width as number };
+    }
+    if (height != undefined) {
+      styleChanges.height = { value: height as number };
+    }
+    props.onResize({ id: `${props.id}`, settings: styleChanges });
+  };
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dCssClass = pModel.customCssClass || cssClass;
@@ -128,7 +137,7 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
     if (sCssClass !== undefined) {
       setCssClass(sCssClass);
     }
-
+    handleStylingChanges();
     setReady(true);
   }, []);
 

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -206,6 +206,40 @@ defmodule Oli.Groups do
   end
 
   @doc """
+  Creates community accounts from user type and emails.
+
+  ## Examples
+
+      iex> create_community_accounts_from_emails("admin", ["foo@foo.com", "bar@bar.com"], %{field: new_value})
+      {:ok, [%CommunityAccount{}, %CommunityAccount{}]}
+
+      iex> create_community_accounts_from_emails("member", ["example@foo.com"], %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+
+  def create_community_accounts_from_emails(user_type, emails, attrs) do
+    {created_accounts, errors} =
+      Enum.reduce(emails, {[], []}, fn email, {created, errors} ->
+        case create_community_account_from_email(user_type, email, attrs) do
+          {:ok, community_account} ->
+            {[community_account | created], errors}
+
+          {:error, error} ->
+            {created, [error | errors]}
+        end
+      end)
+
+    case errors do
+      [error | _errors] ->
+        {:error, error}
+
+      _errors ->
+        {:ok, created_accounts}
+    end
+  end
+
+  @doc """
   Gets a community account by id.
 
   ## Examples

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -234,7 +234,7 @@ defmodule Oli.Groups do
       [error | _errors] ->
         {:error, error}
 
-      _errors ->
+      [] ->
         {:ok, created_accounts}
     end
   end

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -6,7 +6,7 @@ defmodule Oli.Groups do
   import Ecto.Query, warn: false
 
   alias Oli.Accounts
-  alias Oli.Accounts.Author
+  alias Oli.Accounts.{Author, User}
   alias Oli.Groups.{Community, CommunityAccount, CommunityVisibility}
   alias Oli.Repo
 
@@ -115,12 +115,6 @@ defmodule Oli.Groups do
     Community.changeset(community, attrs)
   end
 
-  defp filter_conditions(filter) do
-    Enum.reduce(filter, false, fn {field, value}, conditions ->
-      dynamic([entity], field(entity, ^field) == ^value or ^conditions)
-    end)
-  end
-
   # ------------------------------------------------------------
   # Communities accounts
 
@@ -163,6 +157,52 @@ defmodule Oli.Groups do
       nil ->
         {:error, :author_not_found}
     end
+  end
+
+  @doc """
+  Creates a community account from a user email (gets the user first).
+
+  ## Examples
+
+      iex> create_community_account_from_user_email("example@foo.com", %{field: new_value})
+      {:ok, %CommunityAccount{}}
+
+      iex> create_community_account_from_user_email("example@foo.com", %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+
+  def create_community_account_from_user_email(email, attrs \\ %{}) do
+    case Accounts.get_user_by(%{email: email}) do
+      %User{id: id} ->
+        attrs |> Map.put(:user_id, id) |> create_community_account()
+
+      nil ->
+        {:error, :user_not_found}
+    end
+  end
+
+  @doc """
+  Creates a community account from a user type and email (gets the user first).
+
+  ## Examples
+
+      iex> create_community_account_from_email("admin", "example@foo.com", %{field: new_value})
+      {:ok, %CommunityAccount{}}
+
+      iex> create_community_account_from_user_email("member", "example@foo.com", %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+
+  def create_community_account_from_email(user_type, email, attrs \\ %{})
+
+  def create_community_account_from_email("admin", email, attrs) do
+    create_community_account_from_author_email(email, attrs)
+  end
+
+  def create_community_account_from_email("member", email, attrs) do
+    create_community_account_from_user_email(email, attrs)
   end
 
   @doc """
@@ -227,8 +267,7 @@ defmodule Oli.Groups do
       from(
         community_account in CommunityAccount,
         join: author in assoc(community_account, :author),
-        where:
-          community_account.community_id == ^community_id and community_account.is_admin == true,
+        where: community_account.community_id == ^community_id and community_account.is_admin,
         select: author
       )
     )
@@ -312,5 +351,35 @@ defmodule Oli.Groups do
       }
     )
     |> Repo.all()
+  end
+
+  @doc """
+  Get all the members for a specific community.
+
+  ## Examples
+
+      iex> list_community_members(1)
+      {:ok, [%User{}, ...]}
+
+      iex> list_community_members(123)
+      {:ok, []}
+  """
+  def list_community_members(community_id, limit \\ nil) do
+    Repo.all(
+      from(
+        community_account in CommunityAccount,
+        join: member in assoc(community_account, :user),
+        where: community_account.community_id == ^community_id and not community_account.is_admin,
+        select: member,
+        order_by: [desc: :inserted_at],
+        limit: ^limit
+      )
+    )
+  end
+
+  defp filter_conditions(filter) do
+    Enum.reduce(filter, false, fn {field, value}, conditions ->
+      dynamic([entity], field(entity, ^field) == ^value or ^conditions)
+    end)
   end
 end

--- a/lib/oli/groups/community.ex
+++ b/lib/oli/groups/community.ex
@@ -2,6 +2,8 @@ defmodule Oli.Groups.Community do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @string_field_limit 256
+
   schema "communities" do
     field :name, :string
     field :description, :string
@@ -29,5 +31,7 @@ defmodule Oli.Groups.Community do
     |> cast(attrs, [:name, :description, :key_contact, :global_access, :status])
     |> validate_required([:name, :global_access, :status])
     |> unique_constraint(:name)
+    |> validate_length(:name, max: @string_field_limit)
+    |> validate_length(:key_contact, max: @string_field_limit)
   end
 end

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -403,6 +403,7 @@ defmodule Oli.Seeder do
           start_date: ~U[2010-04-17 00:00:00.000000Z],
           timezone: "some timezone",
           title: "some title",
+          description: "a description",
           context_id: UUID.uuid4(),
           base_project_id: map.project.id,
           institution_id: map.institution.id

--- a/lib/oli_web/common/params.ex
+++ b/lib/oli_web/common/params.ex
@@ -50,4 +50,10 @@ defmodule OliWeb.Common.Params do
         end
     end
   end
+
+  def trim(params) do
+    Enum.reduce(params, %{}, fn {field, value}, acc ->
+      Map.put(acc, field, String.trim(value))
+    end)
+  end
 end

--- a/lib/oli_web/controllers/api/product_controller.ex
+++ b/lib/oli_web/controllers/api/product_controller.ex
@@ -38,6 +38,7 @@ defmodule OliWeb.Api.ProductController do
           %{
             "slug" => "my_first_product",
             "title" => "Introduction to World Cultures",
+            "description" => "World Cultures is a great....",
             "status" => "active",
             "requires_payment" => true,
             "amount" => "$100.00",

--- a/lib/oli_web/live/community_live/account_invitation.ex
+++ b/lib/oli_web/live/community_live/account_invitation.ex
@@ -13,6 +13,7 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
   prop to_invite, :any, default: :collaborator
   prop placeholder, :string, default: "collaborator@example.edu"
   prop button_text, :string, default: "Send invite"
+  prop allow_removal, :boolean, default: true
 
   def render(assigns) do
     ~F"""
@@ -34,9 +35,11 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
             <div>{collaborator.name}</div>
             <div class="text-muted">{collaborator.email}</div>
           </div>
-          <div class="user-actions">
-            <button class="btn btn-link text-danger" :on-click={@remove} phx-value-collaborator-id={collaborator.id}>Remove</button>
-          </div>
+          {#if @allow_removal}
+            <div class="user-actions">
+              <button class="btn btn-link text-danger" :on-click={@remove} phx-value-collaborator-id={collaborator.id}>Remove</button>
+            </div>
+          {/if}
         </div>
       {/for}
     """

--- a/lib/oli_web/live/community_live/account_invitation.ex
+++ b/lib/oli_web/live/community_live/account_invitation.ex
@@ -4,24 +4,30 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
   alias Surface.Components.Form
   alias Surface.Components.Form.{ErrorTag, Field, TextInput}
 
+  prop list_id, :string, required: true
   prop invite, :event, required: true
   prop remove, :event, required: true
+  prop suggest, :event
   prop collaborators, :any, default: []
+  prop matches, :any, default: []
   prop to_invite, :any, default: :collaborator
   prop placeholder, :string, default: "collaborator@example.edu"
   prop button_text, :string, default: "Send invite"
 
   def render(assigns) do
     ~F"""
-      <Form for={@to_invite} submit={@invite} class="d-flex mb-5">
+      <Form for={@to_invite} submit={@invite} change={@suggest} class="d-flex mb-5">
         <Field name={:email} class="w-100">
-          <TextInput class="form-control" opts={placeholder: @placeholder}/>
+          <TextInput class="form-control" opts={placeholder: @placeholder, autocomplete: "off", list: @list_id}/>
+          <datalist id={@list_id}>
+            {#for match <- @matches}
+              <option value={match.email}>{match.name}</option>
+            {/for}
+          </datalist>
           <ErrorTag/>
         </Field>
-
         <button class="form-button btn btn-outline-primary" type="submit">{@button_text}</button>
       </Form>
-
       {#for collaborator <- @collaborators}
         <div class="d-flex justify-content-between align-items-center mb-3">
           <div class="d-flex flex-column">

--- a/lib/oli_web/live/community_live/associated/new_view.ex
+++ b/lib/oli_web/live/community_live/associated/new_view.ex
@@ -114,7 +114,7 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
 
     case Groups.create_community_visibility(attrs) do
       {:ok, _community_visibility} ->
-        socket = put_flash(socket, :info, "Association to #{type} succesfully added.")
+        socket = put_flash(socket, :info, "Association to #{type} successfully added.")
 
         sources = retrieve_all_sources(socket.assigns.community_id)
         {:ok, table_model} = TableModel.new(sources)

--- a/lib/oli_web/live/community_live/form.ex
+++ b/lib/oli_web/live/community_live/form.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.CommunityLive.Form do
         {#if @display_labels}
           <Label class="control-label">Community Name</Label>
         {/if}
-        <TextInput class="form-control" opts={placeholder: "Name"}/>
+        <TextInput class="form-control" opts={placeholder: "Name", maxlength: "256"}/>
         <ErrorTag/>
       </Field>
 
@@ -30,7 +30,8 @@ defmodule OliWeb.CommunityLive.Form do
         {#if @display_labels}
           <Label class="control-label">Community Contact</Label>
         {/if}
-        <TextInput class="form-control" opts={placeholder: "Key Contact"}/>
+        <TextInput class="form-control" opts={placeholder: "Key Contact", maxlength: "256"}/>
+        <ErrorTag/>
       </Field>
 
       <Field name={:global_access} class="form-check">

--- a/lib/oli_web/live/community_live/members_index_view.ex
+++ b/lib/oli_web/live/community_live/members_index_view.ex
@@ -1,0 +1,109 @@
+defmodule OliWeb.CommunityLive.MembersIndexView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.SortableTable.TableHandlers
+
+  alias Oli.Groups
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.CommunityLive.{ShowView, MembersTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+
+  data title, :string, default: "Community Members"
+  data breadcrumbs, :any
+
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+  data show_bottom_paging, :boolean, default: false
+  data additional_table_class, :string, default: ""
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, query, _filter) do
+    Enum.filter(socket.assigns.members, fn m ->
+      String.contains?(String.downcase(m.name), String.downcase(query)) or
+        String.contains?(String.downcase(m.email), String.downcase(query))
+    end)
+  end
+
+  def live_path(socket, params) do
+    Routes.live_path(socket, __MODULE__, socket.assigns.community_id, params)
+  end
+
+  def breadcrumb(community_id) do
+    ShowView.breadcrumb(community_id) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Members",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, community_id)
+        })
+      ]
+  end
+
+  def mount(%{"community_id" => community_id}, _session, socket) do
+    members = Groups.list_community_members(community_id)
+    {:ok, table_model} = MembersTableModel.new(members)
+
+    {:ok,
+     assign(socket,
+       breadcrumbs: breadcrumb(community_id),
+       members: members,
+       community_id: community_id,
+       table_model: table_model,
+       total_count: length(members)
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="d-flex p-3 justify-content-between">
+        <Filter
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query}/>
+      </div>
+
+      <div class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={@show_bottom_paging}
+          additional_table_class={@additional_table_class}/>
+      </div>
+    """
+  end
+
+  def handle_event("remove", %{"id" => id}, socket) do
+    socket = clear_flash(socket)
+
+    case Groups.delete_community_account(%{
+           community_id: socket.assigns.community_id,
+           user_id: id
+         }) do
+      {:ok, _community_account} ->
+        socket = put_flash(socket, :info, "Community member successfully removed.")
+
+        members = Groups.list_community_members(socket.assigns.community_id)
+        {:ok, table_model} = MembersTableModel.new(members)
+
+        {:noreply,
+         assign(socket,
+           members: members,
+           table_model: table_model,
+           total_count: length(members)
+         )}
+
+      {:error, _error} ->
+        {:noreply, put_flash(socket, :error, "Community member couldn't be removed.")}
+    end
+  end
+end

--- a/lib/oli_web/live/community_live/members_table_model.ex
+++ b/lib/oli_web/live/community_live/members_table_model.ex
@@ -1,0 +1,40 @@
+defmodule OliWeb.CommunityLive.MembersTableModel do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+
+  def new(members) do
+    SortableTableModel.new(
+      rows: members,
+      column_specs: [
+        %ColumnSpec{
+          name: :name,
+          label: "Name"
+        },
+        %ColumnSpec{
+          name: :email,
+          label: "Email"
+        },
+        %ColumnSpec{
+          name: :actions,
+          label: "Actions",
+          render_fn: &__MODULE__.render_remove_button/3
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id]
+    )
+  end
+
+  def render_remove_button(assigns, item, _) do
+    ~F"""
+      <button class="btn btn-primary" phx-click="remove" phx-value-id={item.id}>Remove</button>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -39,10 +39,7 @@ defmodule OliWeb.CommunityLive.NewView do
   def handle_event("save", %{"community" => params}, socket) do
     socket = clear_flash(socket)
 
-    params
-    |> Params.trim()
-    |> Groups.create_community()
-    |> case do
+    case Groups.create_community(Params.trim(params)) do
       {:ok, _community} ->
         {:noreply,
          socket

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -37,6 +37,8 @@ defmodule OliWeb.CommunityLive.NewView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
+    socket = clear_flash(socket)
+
     params
     |> Params.trim()
     |> Groups.create_community()

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.CommunityLive.NewView do
 
   alias Oli.Groups
   alias Oli.Groups.Community
-  alias OliWeb.Common.{Breadcrumb, FormContainer}
+  alias OliWeb.Common.{Breadcrumb, FormContainer, Params}
   alias OliWeb.CommunityLive.{Form, IndexView}
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -37,7 +37,10 @@ defmodule OliWeb.CommunityLive.NewView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
-    case Groups.create_community(params) do
+    params
+    |> Params.trim()
+    |> Groups.create_community()
+    |> case do
       {:ok, _community} ->
         {:noreply,
          socket

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.CommunityLive.ShowView do
   alias Oli.Accounts.{AuthorBrowseOptions, UserBrowseOptions}
   alias Oli.Groups
   alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{Breadcrumb, DeleteModal}
+  alias OliWeb.Common.{Breadcrumb, DeleteModal, Params}
   alias OliWeb.CommunityLive.Associated.IndexView, as: IndexAssociated
   alias Surface.Components.Link
 
@@ -137,7 +137,7 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
-    case Groups.update_community(socket.assigns.community, params) do
+    case Groups.update_community(socket.assigns.community, Params.trim(params)) do
       {:ok, community} ->
         socket = put_flash(socket, :info, "Community successfully updated.")
 

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -231,18 +231,9 @@ defmodule OliWeb.CommunityLive.ShowView do
         {:ok, _community_accounts} ->
           put_flash(socket, :info, "Community #{user_type}(s) successfully added.")
 
-        {:error, error} ->
+        {:error, _error} ->
           message =
-            case error do
-              :author_not_found ->
-                "Community admin couldn't be added. Author does not exist."
-
-              :user_not_found ->
-                "Community member couldn't be added. User does not exist."
-
-              %Ecto.Changeset{} ->
-                "Community user couldn't be added. It is already associated to the community or an unexpected error occurred."
-            end
+            "Some of the community #{user_type}s couldn't be added because the users don't exist in the system or are already associated."
 
           put_flash(socket, :error, message)
       end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -2,7 +2,10 @@ defmodule OliWeb.CommunityLive.ShowView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
   use OliWeb.Common.Modal
 
+  alias Oli.Accounts
+  alias Oli.Accounts.{AuthorBrowseOptions, UserBrowseOptions}
   alias Oli.Groups
+  alias Oli.Repo.{Paging, Sorting}
   alias OliWeb.Common.{Breadcrumb, DeleteModal}
   alias OliWeb.CommunityLive.Associated.IndexView, as: IndexAssociated
   alias Surface.Components.Link
@@ -11,10 +14,12 @@ defmodule OliWeb.CommunityLive.ShowView do
     Form,
     IndexView,
     AccountInvitation,
-    ShowSection
+    ShowSection,
+    MembersIndexView
   }
 
   alias OliWeb.Router.Helpers, as: Routes
+  alias Surface.Components.Link
 
   data title, :string, default: "Edit Community"
   data community, :struct
@@ -22,11 +27,14 @@ defmodule OliWeb.CommunityLive.ShowView do
   data breadcrumbs, :list
   data modal, :any, default: nil
   data community_admins, :list
+  data community_members, :list
+  data matches, :map, default: %{"admin" => [], "member" => []}
 
   @delete_modal_description """
     This action will not affect existing course sections that are using this community.
     Those sections will continue to operate as intended.
   """
+  @matches_limit 30
 
   def breadcrumb(community_id) do
     IndexView.breadcrumb() ++
@@ -49,13 +57,15 @@ defmodule OliWeb.CommunityLive.ShowView do
         community ->
           changeset = Groups.change_community(community)
           community_admins = Groups.list_community_admins(community_id)
+          community_members = Groups.list_community_members(community_id, 3)
 
           assign(socket,
             community: community,
             changeset: changeset,
             breadcrumbs: breadcrumb(community_id),
             community_admins: community_admins,
-            community_id: community_id
+            community_id: community_id,
+            community_members: community_members
           )
       end
 
@@ -66,7 +76,10 @@ defmodule OliWeb.CommunityLive.ShowView do
     ~F"""
       {render_modal(assigns)}
       <div id="community-overview" class="overview container">
-        <ShowSection section_title="Details" section_description="Main community fields that will be shown to system admins and community admins.">
+        <ShowSection
+          section_title="Details"
+          section_description="Main community fields that will be shown to system admins and community admins."
+        >
           <Form changeset={@changeset} save="save"/>
         </ShowSection>
 
@@ -75,11 +88,33 @@ defmodule OliWeb.CommunityLive.ShowView do
           section_description="Add other authors by email to administrate the community."
         >
           <AccountInvitation
-            invite="add_collaborator"
-            remove="remove_collaborator"
+            list_id="admin_matches"
+            invite="add_admin"
+            remove="remove_admin"
+            suggest="suggest_admin"
+            matches={@matches["admin"]}
             placeholder="admin@example.edu"
             button_text="Add"
             collaborators={@community_admins}/>
+        </ShowSection>
+
+        <ShowSection
+          section_title="Community Members"
+          section_description="Add users by email as members of the community. Only showing the last 3 additions here."
+        >
+          <AccountInvitation
+            list_id="member_matches"
+            invite="add_member"
+            remove="remove_member"
+            suggest="suggest_member"
+            matches={@matches["member"]}
+            placeholder="user@example.edu"
+            button_text="Add"
+            collaborators={@community_members}/>
+
+          <Link class="btn btn-link float-right mt-4" to={Routes.live_path(@socket, MembersIndexView, @community.id)}>
+            See all >
+          </Link>
         </ShowSection>
 
         <ShowSection
@@ -172,20 +207,20 @@ defmodule OliWeb.CommunityLive.ShowView do
     {:noreply, assign(socket, modal: modal)}
   end
 
-  def handle_event("add_collaborator", %{"collaborator" => %{"email" => email}}, socket) do
+  def handle_event("add_" <> user_type, %{"collaborator" => %{"email" => email}}, socket) do
     socket = clear_flash(socket)
 
     attrs = %{
       community_id: socket.assigns.community.id,
-      is_admin: true
+      is_admin: user_type == "admin"
     }
 
-    case Groups.create_community_account_from_author_email(email, attrs) do
+    case Groups.create_community_account_from_email(user_type, email, attrs) do
       {:ok, _community_account} ->
-        socket = put_flash(socket, :info, "Admin successfully added.")
-        community_admins = Groups.list_community_admins(attrs.community_id)
+        socket = put_flash(socket, :info, "Community #{user_type} successfully added.")
+        updated_assigns = community_accounts_assigns(user_type, attrs.community_id)
 
-        {:noreply, assign(socket, community_admins: community_admins)}
+        {:noreply, assign(socket, updated_assigns)}
 
       {:error, error} ->
         message =
@@ -193,31 +228,74 @@ defmodule OliWeb.CommunityLive.ShowView do
             :author_not_found ->
               "Community admin couldn't be added. Author does not exist."
 
+            :user_not_found ->
+              "Community member couldn't be added. User does not exist."
+
             %Ecto.Changeset{} ->
-              "Community admin couldn't be added. Author is already an admin or an unexpected error occurred."
+              "Community user couldn't be added. It is already associated to the community or an unexpected error occurred."
           end
 
         {:noreply, put_flash(socket, :error, message)}
     end
   end
 
-  def handle_event("remove_collaborator", %{"collaborator-id" => admin_id}, socket) do
+  def handle_event("remove_" <> user_type, %{"collaborator-id" => user_id}, socket) do
     socket = clear_flash(socket)
 
-    attrs = %{
-      community_id: socket.assigns.community.id,
-      author_id: admin_id
-    }
+    attrs =
+      Map.merge(
+        %{
+          community_id: socket.assigns.community.id
+        },
+        case user_type do
+          "admin" -> %{author_id: user_id}
+          "member" -> %{user_id: user_id}
+        end
+      )
 
     case Groups.delete_community_account(attrs) do
       {:ok, _community_account} ->
-        socket = put_flash(socket, :info, "Admin successfully removed.")
-        community_admins = Groups.list_community_admins(attrs.community_id)
+        socket = put_flash(socket, :info, "Community #{user_type} successfully removed.")
+        updated_assigns = community_accounts_assigns(user_type, attrs.community_id)
 
-        {:noreply, assign(socket, community_admins: community_admins)}
+        {:noreply, assign(socket, updated_assigns)}
 
       {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Community admin couldn't be removed.")}
+        {:noreply, put_flash(socket, :error, "Community #{user_type} couldn't be removed.")}
     end
   end
+
+  def handle_event("suggest_" <> user_type, %{"collaborator" => %{"email" => query}}, socket) do
+    matches = Map.put(socket.assigns.matches, user_type, browse_accounts(user_type, query))
+    {:noreply, assign(socket, matches: matches)}
+  end
+
+  defp community_accounts_assigns("admin", community_id),
+    do: [community_admins: Groups.list_community_admins(community_id)]
+
+  defp community_accounts_assigns("member", community_id),
+    do: [community_members: Groups.list_community_members(community_id, 3)]
+
+  defp community_accounts_assigns(_user_type, _community_id), do: []
+
+  defp browse_accounts("member", query),
+    do:
+      Accounts.browse_users(
+        %Paging{offset: 0, limit: @matches_limit},
+        %Sorting{direction: :asc, field: :name},
+        %UserBrowseOptions{
+          include_guests: false,
+          text_search: query
+        }
+      )
+
+  defp browse_accounts("admin", query),
+    do:
+      Accounts.browse_authors(
+        %Paging{offset: 0, limit: @matches_limit},
+        %Sorting{direction: :asc, field: :name},
+        %AuthorBrowseOptions{
+          text_search: query
+        }
+      )
 end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.CommunityLive.ShowView do
       ]
   end
 
-  def mount(%{"community_id" => community_id}, _session, socket) do
+  def mount(%{"community_id" => community_id}, %{"is_system_admin" => is_system_admin}, socket) do
     socket =
       case Groups.get_community(community_id) do
         nil ->
@@ -65,7 +65,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             breadcrumbs: breadcrumb(community_id),
             community_admins: community_admins,
             community_id: community_id,
-            community_members: community_members
+            community_members: community_members,
+            is_system_admin: is_system_admin
           )
       end
 
@@ -95,7 +96,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             matches={@matches["admin"]}
             placeholder="admin@example.edu"
             button_text="Add"
-            collaborators={@community_admins}/>
+            collaborators={@community_admins}
+            allow_removal={@is_system_admin}/>
         </ShowSection>
 
         <ShowSection

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -137,6 +137,8 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
+    socket = clear_flash(socket)
+
     case Groups.update_community(socket.assigns.community, Params.trim(params)) do
       {:ok, community} ->
         socket = put_flash(socket, :info, "Community successfully updated.")
@@ -157,6 +159,8 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("delete", _params, socket) do
+    socket = clear_flash(socket)
+
     socket =
       case Groups.delete_community(socket.assigns.community) do
         {:ok, _community} ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -276,6 +276,7 @@ defmodule OliWeb.Router do
         pipe_through [:authorize_community]
 
         live("/", CommunityLive.ShowView)
+        live("/members", CommunityLive.MembersIndexView)
 
         scope "/associated" do
           live("/", CommunityLive.Associated.IndexView)

--- a/lib/oli_web/views/api/product_view.ex
+++ b/lib/oli_web/views/api/product_view.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Api.ProductView do
   def render("product.json", %{product: product}) do
     %{
       slug: product.slug,
+      description: product.description,
       title: product.title,
       status: product.status,
       requires_payment: product.requires_payment,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.16.0",
+      version: "0.17.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli/groups_test.exs
+++ b/test/oli/groups_test.exs
@@ -96,7 +96,7 @@ defmodule Oli.GroupsTest do
 
   describe "community account" do
     alias Oli.Groups.CommunityAccount
-    alias Oli.Accounts.Author
+    alias Oli.Accounts.{Author, User}
 
     test "create_community_account/1 with valid data creates a community account" do
       params = params_for(:community_account)
@@ -112,13 +112,13 @@ defmodule Oli.GroupsTest do
     test "create_community_account/1 for existing author and community returns error changeset" do
       author = build(:author)
       community = build(:community)
-      insert(:community_account, %{author: author, community: community})
+      insert(:community_admin_account, %{author: author, community: community})
 
       assert {:error, %Ecto.Changeset{}} =
                Groups.create_community_account(%{author: author, community: community})
     end
 
-    test "create_community_account_from_author_email/1 with valid data creates a community account" do
+    test "create_community_account_from_author_email/2 with valid data creates a community account" do
       author = insert(:author)
       params = params_for(:community_account)
 
@@ -130,23 +130,78 @@ defmodule Oli.GroupsTest do
       assert community_account.is_admin == params.is_admin
     end
 
-    test "create_community_account_from_author_email/1 for non existing author email returns author not found" do
+    test "create_community_account_from_author_email/2 for non existing author email returns author not found" do
       params = params_for(:community_account)
 
       assert {:error, :author_not_found} =
                Groups.create_community_account_from_author_email("testing@email.com", params)
     end
 
-    test "create_community_account_from_author_email/1 for existing author and community returns error changeset" do
+    test "create_community_account_from_author_email/2 for existing author and community returns error changeset" do
       author = build(:author)
       community = build(:community)
-      insert(:community_account, %{author: author, community: community})
+      insert(:community_admin_account, %{author: author, community: community})
 
       assert {:error, %Ecto.Changeset{}} =
                Groups.create_community_account_from_author_email(author.email, %{
                  author: author,
                  community: community
                })
+    end
+
+    test "create_community_account_from_user_email/2 with valid data creates a community account" do
+      user = insert(:user)
+      params = params_for(:community_member_account)
+
+      assert {:ok, %CommunityAccount{} = community_account} =
+               Groups.create_community_account_from_user_email(user.email, params)
+
+      assert community_account.user_id == user.id
+      assert community_account.community_id == params.community_id
+      assert community_account.is_admin == params.is_admin
+    end
+
+    test "create_community_account_from_user_email/2 for non existing user email returns author not found" do
+      params = params_for(:community_account)
+
+      assert {:error, :user_not_found} =
+               Groups.create_community_account_from_user_email("testing@email.com", params)
+    end
+
+    test "create_community_account_from_user_email/2 for existing user and community returns error changeset" do
+      user = build(:user)
+      community = build(:community)
+      insert(:community_member_account, %{user: user, community: community})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Groups.create_community_account_from_user_email(user.email, %{
+                 user: user,
+                 community: community
+               })
+    end
+
+    test "create_community_account_from_email/3 with valid data creates a community admin account" do
+      author = insert(:author)
+      params = params_for(:community_admin_account)
+
+      assert {:ok, %CommunityAccount{} = community_account} =
+               Groups.create_community_account_from_email("admin", author.email, params)
+
+      assert community_account.author_id == author.id
+      assert community_account.community_id == params.community_id
+      assert community_account.is_admin == params.is_admin
+    end
+
+    test "create_community_account_from_email/3 with valid data creates a community member account" do
+      user = insert(:user)
+      params = params_for(:community_member_account)
+
+      assert {:ok, %CommunityAccount{} = community_account} =
+               Groups.create_community_account_from_email("member", user.email, params)
+
+      assert community_account.user_id == user.id
+      assert community_account.community_id == params.community_id
+      assert community_account.is_admin == params.is_admin
     end
 
     test "get_community_account/1 returns a community account when the id exists" do
@@ -187,14 +242,28 @@ defmodule Oli.GroupsTest do
     end
 
     test "list_community_admins/1 returns the admins for a community" do
-      community_account = insert(:community_account)
-      insert(:community_account, %{community: community_account.community})
-      insert(:community_account, %{community: community_account.community, is_admin: false})
+      community_account = insert(:community_admin_account)
+      insert(:community_admin_account, %{community: community_account.community})
+      insert(:community_member_account, %{community: community_account.community})
 
       admins = Groups.list_community_admins(community_account.community_id)
 
       assert [%Author{} | _tail] = admins
       assert 2 = length(admins)
+    end
+
+    test "list_community_members/2 returns the members for a community" do
+      insert(:community_admin_account)
+      %CommunityAccount{community: community} = insert(:community_member_account)
+      insert(:community_member_account, %{community: community})
+
+      members = Groups.list_community_members(community.id)
+
+      assert [%User{} | _tail] = members
+      assert 2 = length(members)
+
+      members_limited = Groups.list_community_members(community.id, 1)
+      assert [%User{}] = members_limited
     end
 
     test "get_community_account_by!/1 returns a community account when meets the clauses" do

--- a/test/oli_web/controllers/api/product_controller_test.exs
+++ b/test/oli_web/controllers/api/product_controller_test.exs
@@ -22,8 +22,12 @@ defmodule OliWeb.ProductControllerTest do
         |> get(Routes.product_path(conn, :index))
 
       assert json_response(conn, 200)["products"] |> Enum.count() == 2
-      assert json_response(conn, 200)["products"] |> Enum.find(fn p -> p == %{
+
+      assert json_response(conn, 200)["products"]
+             |> Enum.find(fn p ->
+               p == %{
                  "amount" => Money.to_string!(prod1.amount),
+                 "description" => "a description",
                  "grace_period_days" => prod1.grace_period_days,
                  "grace_period_strategy" => Atom.to_string(prod1.grace_period_strategy),
                  "has_grace_period" => prod1.has_grace_period,
@@ -31,10 +35,14 @@ defmodule OliWeb.ProductControllerTest do
                  "slug" => prod1.slug,
                  "status" => Atom.to_string(prod1.status),
                  "title" => prod1.title
-               } end)
+               }
+             end)
 
-      assert json_response(conn, 200)["products"] |> Enum.find(fn p -> p == %{
+      assert json_response(conn, 200)["products"]
+             |> Enum.find(fn p ->
+               p == %{
                  "amount" => nil,
+                 "description" => nil,
                  "grace_period_days" => 0,
                  "grace_period_strategy" => Atom.to_string(prod2.grace_period_strategy),
                  "has_grace_period" => prod2.has_grace_period,
@@ -42,7 +50,8 @@ defmodule OliWeb.ProductControllerTest do
                  "slug" => prod2.slug,
                  "status" => Atom.to_string(prod2.status),
                  "title" => prod2.title
-               } end)
+               }
+             end)
     end
 
     test "renders error when api key does not have product scope", %{
@@ -87,7 +96,7 @@ defmodule OliWeb.ProductControllerTest do
         :prod1
       )
       |> Seeder.create_product(
-        %{title: "My 2nd product", amount: Money.new(:USD, "24.99")},
+        %{title: "My 2nd product", amount: Money.new(:USD, "24.99"), description: nil},
         :prod2
       )
 

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -857,7 +857,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Association to project succesfully added."
+               "Association to project successfully added."
 
       assert 1 == length(Groups.list_community_visibilities(id))
     end

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -480,10 +480,12 @@ defmodule OliWeb.CommunityLiveTest do
       |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
+      error_message =
+        "Some of the community admins couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+             |> render() =~ error_message
 
       view
       |> element("form[phx-submit=\"add_admin\"")
@@ -491,8 +493,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community admin couldn&#39;t be added. Author does not exist."
+             |> render() =~ error_message
 
       assert 1 == length(Groups.list_community_admins(community.id))
     end
@@ -629,10 +630,12 @@ defmodule OliWeb.CommunityLiveTest do
       |> element("form[phx-submit=\"add_member\"")
       |> render_submit(%{collaborator: %{email: user.email}})
 
+      error_message =
+        "Some of the community members couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+             |> render() =~ error_message
 
       view
       |> element("form[phx-submit=\"add_member\"")
@@ -640,8 +643,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community member couldn&#39;t be added. User does not exist."
+             |> render() =~ error_message
 
       assert 1 == length(Groups.list_community_members(community.id))
     end

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -462,7 +462,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Community admin successfully added."
+               "Community admin(s) successfully added."
 
       assert 2 == length(Groups.list_community_admins(community.id))
     end
@@ -495,6 +495,29 @@ defmodule OliWeb.CommunityLiveTest do
                "Community admin couldn&#39;t be added. Author does not exist."
 
       assert 1 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "adds more than one community admin correctly", %{
+      conn: conn,
+      community: community
+    } do
+      emails = insert_pair(:author) |> Enum.map(& &1.email)
+      insert(:community_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_admins(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_admin\"")
+      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community admin(s) successfully added."
+
+      assert 3 == length(Groups.list_community_admins(community.id))
     end
 
     test "removes community admin correctly", %{
@@ -588,7 +611,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Community member successfully added."
+               "Community member(s) successfully added."
 
       assert 2 == length(Groups.list_community_members(community.id))
     end
@@ -621,6 +644,29 @@ defmodule OliWeb.CommunityLiveTest do
                "Community member couldn&#39;t be added. User does not exist."
 
       assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "adds more than one community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      emails = insert_pair(:user) |> Enum.map(& &1.email)
+      insert(:community_member_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member(s) successfully added."
+
+      assert 3 == length(Groups.list_community_members(community.id))
     end
 
     test "removes community member correctly", %{

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -24,6 +24,10 @@ defmodule OliWeb.CommunityLiveTest do
     Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.Associated.NewView, community_id)
   end
 
+  defp live_view_members_index_route(community_id) do
+    Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.MembersIndexView, community_id)
+  end
+
   defp create_community(_conn) do
     community = insert(:community)
 
@@ -411,13 +415,13 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Admin successfully added."
+               "Community admin successfully added."
 
       assert 2 == length(Groups.list_community_admins(community.id))
     end
@@ -432,16 +436,16 @@ defmodule OliWeb.CommunityLiveTest do
       {:ok, view, _html} = live(conn, live_view_show_route(community.id))
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
       assert view
              |> element("div.alert.alert-danger")
              |> render() =~
-               "Community admin couldn&#39;t be added. Author is already an admin or an unexpected error occurred."
+               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: "wrong@example.com"}})
 
       assert view
@@ -464,13 +468,13 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("button[phx-click=\"remove_collaborator\"")
+      |> element("button[phx-click=\"remove_admin\"")
       |> render_click(%{"collaborator-id" => author.id})
 
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Admin successfully removed."
+               "Community admin successfully removed."
 
       assert 0 == length(Groups.list_community_admins(community.id))
     end
@@ -487,7 +491,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("button[phx-click=\"remove_collaborator\"")
+      |> element("button[phx-click=\"remove_admin\"")
       |> render_click(%{"collaborator-id" => 12345})
 
       assert view
@@ -496,6 +500,159 @@ defmodule OliWeb.CommunityLiveTest do
                "Community admin couldn&#39;t be removed."
 
       assert 1 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "suggests community admin correctly", %{
+      conn: conn,
+      community: community
+    } do
+      author = insert(:author)
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-change=\"suggest_admin\"")
+      |> render_change(%{collaborator: %{email: author.name}})
+
+      assert view
+             |> element("#admin_matches")
+             |> render() =~
+               author.email
+
+      view
+      |> element("form[phx-change=\"suggest_admin\"")
+      |> render_change(%{collaborator: %{email: "other_name"}})
+
+      refute view
+             |> element("#admin_matches")
+             |> render() =~
+               author.email
+    end
+
+    test "adds community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: user.email}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully added."
+
+      assert 2 == length(Groups.list_community_members(community.id))
+    end
+
+    test "displays error messages when adding community member fails", %{
+      conn: conn,
+      community: community
+    } do
+      user = build(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: user.email}})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: "wrong@example.com"}})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community member couldn&#39;t be added. User does not exist."
+
+      assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "removes community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("button[phx-click=\"remove_member\"")
+      |> render_click(%{"collaborator-id" => user.id})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully removed."
+
+      assert 0 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "displays error messages when removing community member fails", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("button[phx-click=\"remove_member\"")
+      |> render_click(%{"collaborator-id" => 12345})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community member couldn&#39;t be removed."
+
+      assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "suggests community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-change=\"suggest_member\"")
+      |> render_change(%{collaborator: %{email: user.name}})
+
+      assert view
+             |> element("#member_matches")
+             |> render() =~
+               user.email
+
+      view
+      |> element("form[phx-change=\"suggest_member\"")
+      |> render_change(%{collaborator: %{email: "other_name"}})
+
+      refute view
+             |> element("#member_matches")
+             |> render() =~
+               user.email
     end
   end
 
@@ -537,6 +694,7 @@ defmodule OliWeb.CommunityLiveTest do
                "Association successfully removed."
 
       refute has_element?(view, "##{cv1.id}")
+
       assert has_element?(view, "p", "None exist")
     end
 
@@ -746,6 +904,151 @@ defmodule OliWeb.CommunityLiveTest do
              |> element("tr:first-child > td:first-child")
              |> render() =~
                section.title
+    end
+  end
+
+  describe "members index" do
+    setup [:admin_conn, :create_community]
+
+    test "loads correctly when there are no members associated to the community", %{
+      conn: conn,
+      community: %Community{id: id}
+    } do
+      {:ok, view, _html} = live(conn, live_view_members_index_route(id))
+
+      assert has_element?(view, "p", "None exist")
+    end
+
+    test "lists community members", %{conn: conn, community: community} do
+      user = insert(:user)
+      insert(:community_member_account, %{user: user, community: community})
+
+      {:ok, view, _html} = live(conn, live_view_members_index_route(community.id))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               user.name
+    end
+
+    test "removes community member", %{conn: conn, community: community} do
+      user = insert(:user)
+      insert(:community_member_account, %{user: user, community: community})
+
+      {:ok, view, _html} = live(conn, live_view_members_index_route(community.id))
+
+      view
+      |> element("tr:first-child > td:last-child > button")
+      |> render_click(%{"id" => user.id})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully removed."
+
+      assert has_element?(view, "p", "None exist")
+    end
+
+    test "applies searching", %{conn: conn, community: community} do
+      user_1 = insert(:user, %{name: "Testing"})
+      user_2 = insert(:user)
+      insert(:community_member_account, %{user: user_1, community: community})
+      insert(:community_member_account, %{user: user_2, community: community})
+
+      {:ok, view, _html} = live(conn, live_view_members_index_route(community.id))
+
+      view
+      |> element("input[phx-blur=\"change_search\"]")
+      |> render_blur(%{value: "testing"})
+
+      view
+      |> element("button[phx-click=\"apply_search\"]")
+      |> render_click()
+
+      view
+      |> element("button[phx-click=\"apply_search\"]")
+      |> render_click()
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               user_1.name
+
+      refute view
+             |> element("tr:last-child > td:first-child")
+             |> render() =~
+               user_2.name
+
+      view
+      |> element("button[phx-click=\"reset_search\"]")
+      |> render_click()
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               user_1.name
+
+      assert view
+             |> element("tr:last-child > td:first-child")
+             |> render() =~
+               user_2.name
+    end
+
+    test "applies sorting", %{conn: conn, community: community} do
+      user_1 = insert(:user, %{name: "Testing A"})
+      user_2 = insert(:user, %{name: "Testing B"})
+      insert(:community_member_account, %{user: user_1, community: community})
+      insert(:community_member_account, %{user: user_2, community: community})
+
+      {:ok, view, _html} = live(conn, live_view_members_index_route(community.id))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing A"
+
+      view
+      |> element("th[phx-click=\"sort\"]:first-of-type")
+      |> render_click(%{sort_by: "name"})
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing B"
+    end
+
+    test "applies paging", %{conn: conn, community: community} do
+      [first_cma | tail] =
+        insert_list(21, :community_member_account, %{community: community})
+        |> Enum.sort_by(& &1.user.name)
+
+      last_cma = List.last(tail)
+
+      {:ok, view, _html} = live(conn, live_view_members_index_route(community.id))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               first_cma.user.name
+
+      refute view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               last_cma.user.name
+
+      view
+      |> element("a[phx-click=\"page_change\"]", "2")
+      |> render_click()
+
+      refute view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               first_cma.user.name
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               last_cma.user.name
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,7 +20,7 @@ defmodule Oli.Factory do
   def user_factory() do
     %User{
       email: "#{sequence("user")}@example.edu",
-      name: "User name",
+      name: sequence("User name"),
       given_name: "User given name",
       family_name: "User family name",
       sub: "#{sequence("usersub")}"
@@ -37,11 +37,12 @@ defmodule Oli.Factory do
     }
   end
 
-  def community_account_factory() do
+  def community_account_factory(), do: struct!(community_admin_account_factory())
+
+  def community_admin_account_factory() do
     %CommunityAccount{
       community: insert(:community),
       author: insert(:author),
-      user: insert(:user),
       is_admin: true
     }
   end
@@ -91,6 +92,14 @@ defmodule Oli.Factory do
       institution_email: "ins@example.edu",
       institution_url: "example.edu",
       timezone: "America/New_York"
+    }
+  end
+
+  def community_member_account_factory() do
+    %CommunityAccount{
+      community: insert(:community),
+      user: insert(:user),
+      is_admin: false
     }
   end
 end


### PR DESCRIPTION
This PR addresses the following bugs:
- [[MER-490]](https://eliterate.atlassian.net/browse/MER-490) Clear flash messages
- [[MER-491]](https://eliterate.atlassian.net/browse/MER-491) Fix typo
- [[MER-492]](https://eliterate.atlassian.net/browse/MER-492) Community admins can delete other community admins
- [[MER-494]](https://eliterate.atlassian.net/browse/MER-494) Community not created when Name is too long
- [[MER-496]](https://eliterate.atlassian.net/browse/MER-496) Community not created when Key Contact is too long
- [[MER-497]](https://eliterate.atlassian.net/browse/MER-497) Can create a community with a duplicate name with surrounding whitespaces.
- [[MER-498]](https://eliterate.atlassian.net/browse/MER-498) Can only add community admins one at a time