### PR TITLE
[BUGFIX] [MER-561] Return exact email results when setting restricted visibility to a project

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -419,14 +419,12 @@ defmodule Oli.Accounts do
   end
 
   @doc """
-  Searches for a list of authors with an email matching a wildcard pattern
+  Searches for a list of authors with an email matching the exact string
   """
-  def search_authors_matching(query, exact_match \\ false) do
-    q = if exact_match, do: query, else: "%#{query}%"
-
+  def search_authors_matching(query) do
     Repo.all(
       from(author in Author,
-        where: ilike(author.email, ^q)
+        where: ilike(author.email, ^query)
       )
     )
   end

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -314,6 +314,7 @@ defmodule Oli.Accounts do
   Returns true if an author is an administrator.
   """
   def is_admin?(nil), do: false
+
   def is_admin?(%Author{system_role_id: system_role_id}) do
     SystemRole.role_id().admin == system_role_id
   end
@@ -420,9 +421,8 @@ defmodule Oli.Accounts do
   @doc """
   Searches for a list of authors with an email matching a wildcard pattern
   """
-  def search_authors_matching(query) do
-    q = query
-    q = "%" <> q <> "%"
+  def search_authors_matching(query, exact_match \\ false) do
+    q = if exact_match, do: query, else: "%#{query}%"
 
     Repo.all(
       from(author in Author,

--- a/lib/oli_web/live/projects/visibility.ex
+++ b/lib/oli_web/live/projects/visibility.ex
@@ -177,7 +177,7 @@ defmodule OliWeb.Projects.VisibilityLive do
       "instructors" ->
         list =
           if String.length(query) > 1 do
-            Accounts.search_authors_matching(query, true)
+            Accounts.search_authors_matching(query)
           else
             []
           end

--- a/lib/oli_web/live/projects/visibility.ex
+++ b/lib/oli_web/live/projects/visibility.ex
@@ -82,7 +82,7 @@ defmodule OliWeb.Projects.VisibilityLive do
                     <form phx-change="search" class="form-inline form-grow">
                       <%= text_input :search_field, :query, placeholder: "Search for users by email here",
                                     class: "form-control form-control-sm mb-2 mb-sm-0 title container-fluid flex-fill",
-                                    autofocus: true, "phx-debounce": "300" %>
+                                    autofocus: true, "phx-debounce": "300", autocomplete: "off" %>
                       <%= hidden_input :search_field, :entity, value: "instructors" %>
                     </form>
                   </div>
@@ -177,7 +177,7 @@ defmodule OliWeb.Projects.VisibilityLive do
       "instructors" ->
         list =
           if String.length(query) > 1 do
-            Accounts.search_authors_matching(query)
+            Accounts.search_authors_matching(query, true)
           else
             []
           end

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -44,6 +44,16 @@ defmodule Oli.AccountsTest do
       assert author.system_role_id == Accounts.SystemRole.role_id().admin
       assert Accounts.is_admin?(author) == true
     end
+
+    test "search_authors_matching/1 returns authors matching the input exactly" do
+      author = insert(:author)
+      assert [author] == Accounts.search_authors_matching(author.email)
+    end
+
+    test "search_authors_matching/1 returns nothing when only matching a prefix" do
+      author = insert(:author)
+      assert [] == Accounts.search_authors_matching(String.slice(author.email, 0..3))
+    end
   end
 
   describe "users" do

--- a/test/oli_web/live/project_visibility_test.exs
+++ b/test/oli_web/live/project_visibility_test.exs
@@ -39,6 +39,42 @@ defmodule OliWeb.ProjectVisibilityTest do
 
       assert Enum.count(available_publications) == 1
     end
+
+    test "suggests exact email matches when restricted visibility", %{
+      conn: conn,
+      project: project,
+      author: author
+    } do
+      {:ok, view, _} =
+        live_isolated(conn, OliWeb.Projects.VisibilityLive,
+          session: %{"project_slug" => project.slug}
+        )
+
+      view
+      |> element("#visibility_option")
+      |> render_change(%{"visibility" => %{"option" => "selected"}})
+
+      updated_project = Course.get_project!(project.id)
+      assert updated_project.visibility == :selected
+
+      # It doesn't search by prefix
+      email_prefix = String.slice(author.email, 0..3)
+
+      view
+      |> element("#users form")
+      |> render_change(%{"search_field" => %{"entity" => "instructors", "query" => email_prefix}})
+
+      refute has_element?(view, "#user_submit")
+
+      # It searches by exact email
+      view
+      |> element("#users form")
+      |> render_change(%{"search_field" => %{"entity" => "instructors", "query" => author.email}})
+
+      assert view
+             |> element("#user_submit select")
+             |> render() =~ author.email
+    end
   end
 
   defp setup_session(%{conn: conn}) do


### PR DESCRIPTION
[MER-561](https://eliterate.atlassian.net/browse/MER-561)

This PR fixes the bug that currently suggests all the existing authors matching the email substring from the input.
Instead, we want to only list the emails that match exactly with the input string.

