### PR TITLE
[FEATURE] [MER-350] Instructors permissions based on communities

### DIFF
--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -355,7 +355,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
       on:
         section.id ==
           community_visibility.section_id and community_visibility.community_id == ^community_id,
-      where: is_nil(community_visibility.id),
+      where: is_nil(community_visibility.id) and section.type == :blueprint,
       select: section
     )
     |> Repo.all()

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -10,6 +10,8 @@ defmodule Oli.Groups do
   alias Oli.Groups.{Community, CommunityAccount, CommunityInstitution, CommunityVisibility}
   alias Oli.Institutions
   alias Oli.Institutions.Institution
+  alias Oli.Publishing
+  alias Oli.Publishing.Publication
   alias Oli.Repo
 
   # ------------------------------------------------------------
@@ -400,6 +402,119 @@ defmodule Oli.Groups do
     |> Repo.all()
   end
 
+  @doc """
+  Get all the communities the user belongs and/or the communities the
+  user's institution belongs
+
+  ## Examples
+
+      iex> list_associated_communities(1, %Institution{})
+      [%Community{}, ...]
+
+      iex> list_associated_communities(123, %Institution{})
+      []
+  """
+  def list_associated_communities(user_id, institution),
+    do: Repo.all(associated_communities_query(user_id, institution))
+
+  @doc """
+  Get all the publications associated with:
+    - The communities the user belongs
+    - The communities the user's institution belongs
+
+  ## Examples
+
+      iex> list_community_associated_publications(1, %Institution{})
+      [%Publication{project: %Project{}}, ...]
+
+      iex> list_community_associated_publications(123, %Institution{})
+      []
+  """
+  def list_community_associated_publications(user_id, institution) do
+    from(
+      community in Community,
+      join:
+        associated_communities in subquery(associated_communities_query(user_id, institution)),
+      on: associated_communities.id == community.id,
+      join: community_visibility in CommunityVisibility,
+      on: community_visibility.community_id == community.id,
+      left_join: project in assoc(community_visibility, :project),
+      join: last_publication in subquery(Publishing.last_publication_query()),
+      on: last_publication.project_id == project.id,
+      join: publication in Publication,
+      on: publication.id == last_publication.id,
+      select: %{publication | project: project},
+      group_by: [project.id, publication.id]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Get all the publications and products associated with:
+    - The communities the user belongs
+    - The communities the user's institution belongs
+
+  ## Examples
+
+      iex> list_community_associated_publications_and_products(1, %Institution{})
+      [{%Publication{project: %Project{}}, nil}, {%Publication{}, %Section{}}, ...]
+
+      iex> list_community_associated_publications_and_products(123, %Institution{})
+      []
+  """
+  def list_community_associated_publications_and_products(user_id, institution) do
+    from(
+      community in Community,
+      join:
+        associated_communities in subquery(associated_communities_query(user_id, institution)),
+      on: associated_communities.id == community.id,
+      join: community_visibility in CommunityVisibility,
+      on: community_visibility.community_id == community.id,
+      left_join: project in assoc(community_visibility, :project),
+      left_join: section in assoc(community_visibility, :section),
+      join: last_publication in subquery(Publishing.last_publication_query()),
+      on:
+        last_publication.project_id == project.id or
+          last_publication.project_id == section.base_project_id,
+      join: publication in Publication,
+      on: publication.id == last_publication.id,
+      select:
+        {%{
+           publication
+           | project: project
+         }, section},
+      distinct: true
+    )
+    |> Repo.all()
+  end
+
+  defp associated_communities_query(user_id, institution) do
+    user_communities_query =
+      from community in Community,
+        join: community_account in CommunityAccount,
+        on:
+          community.id == community_account.community_id and community_account.user_id == ^user_id,
+        select: community
+
+    case institution do
+      nil ->
+        user_communities_query
+
+      %Institution{id: institution_id} ->
+        institution_communities_query =
+          from community in Community,
+            join: community_institution in CommunityInstitution,
+            on:
+              community.id == community_institution.community_id and
+                community_institution.institution_id == ^institution_id,
+            select: community
+
+        from user_communities_query,
+          union: ^institution_communities_query,
+          distinct: true
+    end
+  end
+
   # ------------------------------------------------------------
   # Communities institutions
 
@@ -516,6 +631,8 @@ defmodule Oli.Groups do
       community_institution -> Repo.delete(community_institution)
     end
   end
+
+  # ------------------------------------------------------------
 
   defp filter_conditions(filter) do
     Enum.reduce(filter, false, fn {field, value}, conditions ->

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -84,7 +84,7 @@ defmodule OliWeb.Delivery.RemixSection do
       |> Repo.preload(:institution)
 
     available_publications =
-      Publishing.available_publications(current_user.author, section.institution)
+      Sections.retrieve_visible_publications(current_user, section.institution)
 
     # only permit instructor or admin level access
 

--- a/lib/oli_web/live/delivery/select_source.ex
+++ b/lib/oli_web/live/delivery/select_source.ex
@@ -1,13 +1,11 @@
 defmodule OliWeb.Delivery.SelectSource do
   use Surface.LiveView
 
-  alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.Filter
-  alias OliWeb.Common.Listing
-  alias OliWeb.Common.Breadcrumb
-  alias Oli.Delivery.Sections.Blueprint
   alias Oli.Accounts
-  alias Oli.Institutions.Institution
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Blueprint
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Router.Helpers, as: Routes
 
   data breadcrumbs, :any,
     default: [Breadcrumb.new(%{full_title: "Select Source for New Section"})]
@@ -74,7 +72,7 @@ defmodule OliWeb.Delivery.SelectSource do
     route = socket.assigns.live_action
 
     sources =
-      retrieve_all_sources(route, maybe_get_author(session))
+      retrieve_all_sources(route, session)
       |> Enum.with_index(fn element, index -> Map.put(element, :unique_id, index) end)
 
     total_count = length(sources)
@@ -124,41 +122,10 @@ defmodule OliWeb.Delivery.SelectSource do
 
   use OliWeb.Common.SortableTable.TableHandlers
 
-  # This route is used in both authoring and delivery.
-  # A user may have a linked author account or it may not.
-  # We check the session for the author_id or user_id which
-  # are both set by plugs in the router.
-  defp maybe_get_author(session) do
-    cond do
-      Map.has_key?(session, "current_author_id") ->
-        Accounts.get_author!(session["current_author_id"])
+  defp retrieve_all_sources(:admin, _session) do
+    products = Blueprint.list()
 
-      Map.has_key?(session, "current_user_id") ->
-        session["current_user_id"]
-        |> Accounts.get_user!(preload: [:author])
-        |> Map.get(:author)
-
-      true ->
-        nil
-    end
-  end
-
-  defp retrieve_all_sources(route, author) do
-    products = get_products(route, author)
-    project_publications = get_publications(route, author, products)
-
-    project_publications ++ products
-  end
-
-  defp get_products(:admin, _author), do: Blueprint.list()
-
-  defp get_products(:independent_learner, author) do
-    Blueprint.available_products(author, empty_institution())
-  end
-
-  # Admins filter to free pubs
-  defp get_publications(:admin, _author, products),
-    do:
+    free_project_publications =
       Oli.Publishing.all_available_publications()
       |> then(fn publications ->
         Blueprint.filter_for_free_projects(
@@ -167,11 +134,14 @@ defmodule OliWeb.Delivery.SelectSource do
         )
       end)
 
-  defp get_publications(:independent_learner, author, _products),
-    do: Oli.Publishing.available_publications(author, empty_institution())
+    free_project_publications ++ products
+  end
 
-  defp empty_institution(),
-    do: %Institution{
-      id: -1
-    }
+  defp retrieve_all_sources(:independent_learner, session) do
+    Sections.retrieve_visible_sources(
+      session["current_user_id"]
+      |> Accounts.get_user!(preload: [:author]),
+      nil
+    )
+  end
 end

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -993,6 +993,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_associated_index_route(community.id))
 
+      assert has_element?(view, "##{first_cv.id}")
       refute has_element?(view, "##{last_cv.id}")
 
       view

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,10 +2,11 @@ defmodule Oli.Factory do
   use ExMachina.Ecto, repo: Oli.Repo
 
   alias Oli.Accounts.{Author, User}
-  alias Oli.Authoring.Course.{Family, Project}
+  alias Oli.Authoring.Course.{Family, Project, ProjectVisibility}
   alias Oli.Delivery.Sections.Section
   alias Oli.Groups.{Community, CommunityAccount, CommunityInstitution, CommunityVisibility}
   alias Oli.Institutions.Institution
+  alias Oli.Publishing.Publication
 
   def author_factory() do
     %Author{
@@ -23,7 +24,8 @@ defmodule Oli.Factory do
       name: sequence("User name"),
       given_name: "User given name",
       family_name: "User family name",
-      sub: "#{sequence("usersub")}"
+      sub: "#{sequence("usersub")}",
+      author: insert(:author)
     }
   end
 
@@ -47,11 +49,19 @@ defmodule Oli.Factory do
     }
   end
 
-  def community_visibility_factory() do
+  def community_visibility_factory(), do: struct!(community_project_visibility_factory())
+
+  def community_project_visibility_factory() do
     %CommunityVisibility{
       community: insert(:community),
-      project: insert(:project),
-      section: nil
+      project: insert(:project)
+    }
+  end
+
+  def community_product_visibility_factory() do
+    %CommunityVisibility{
+      community: insert(:community),
+      section: insert(:section)
     }
   end
 
@@ -61,7 +71,40 @@ defmodule Oli.Factory do
       title: "Example Course",
       slug: sequence("examplecourse"),
       version: "1",
-      family: insert(:family)
+      family: insert(:family),
+      visibility: :global,
+      authors: insert_list(2, :author)
+    }
+  end
+
+  def project_visibility_factory(), do: struct!(project_author_visibility_factory())
+
+  def project_author_visibility_factory() do
+    project = insert(:project)
+    author = insert(:author)
+
+    %ProjectVisibility{
+      project_id: project.id,
+      author_id: author.id
+    }
+  end
+
+  def project_institution_visibility_factory() do
+    project = insert(:project)
+    institution = insert(:institution)
+
+    %ProjectVisibility{
+      project_id: project.id,
+      institution_id: institution.id
+    }
+  end
+
+  def publication_factory() do
+    {:ok, date, _timezone} = DateTime.from_iso8601("2019-05-22 20:30:00Z")
+
+    %Publication{
+      published: date,
+      project: insert(:project)
     }
   end
 


### PR DESCRIPTION
Story: https://eliterate.atlassian.net/browse/MER-350

This feature improves the instructor permissions to select projects and products based on communities logic.

Places where things changed:
- LTI instructor in getting started create course section
- LMS Lite instructor in create new open and free sections
- Remix when editing a section (just listing publications)


Instructor will see projects and products when:
- They are part of a community assigned to their institution
- They are part of a community as a user
- If they have a linked author account
  - They are an author of content
  - An author has made content visible to their institution
  - Another author has shared content with them
- Global -> will see them when they are not associated to any community, or one of the associated communities allows it