### PR TITLE
[MER-624] Make help provider a configurable env variable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -115,7 +115,14 @@ config :oli, :recaptcha,
   secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
 
 # Configure help
-config :oli, :help, dispatcher: Oli.Help.Providers.EmailHelp
+# HELP_PROVIDER env var must be a string representing an existing provider module, such as "EmailHelp"
+help_provider =
+  case System.get_env("HELP_PROVIDER") do
+    nil -> Oli.Help.Providers.EmailHelp
+    provider -> Module.concat([Oli, Help, Providers, provider])
+  end
+
+config :oli, :help, dispatcher: help_provider
 
 config :lti_1p3,
   provider: Lti_1p3.DataProviders.EctoProvider,
@@ -124,7 +131,7 @@ config :lti_1p3,
     schemas: [
       user: Oli.Accounts.User,
       registration: Oli.Lti_1p3.Tool.Registration,
-      deployment: Oli.Lti_1p3.Tool.Deployment,
+      deployment: Oli.Lti_1p3.Tool.Deployment
     ]
   ]
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -126,7 +126,14 @@ config :oli, :recaptcha,
   secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
 
 # Configure help
-config :oli, :help, dispatcher: Oli.Help.Providers.FreshdeskHelp
+# HELP_PROVIDER env var must be a string representing an existing provider module, such as "FreshdeskHelp"
+help_provider =
+  case System.get_env("HELP_PROVIDER") do
+    nil -> Oli.Help.Providers.FreshdeskHelp
+    provider -> Module.concat([Oli, Help, Providers, provider])
+  end
+
+config :oli, :help, dispatcher: help_provider
 
 config :oli, OliWeb.Endpoint,
   server: true,

--- a/oli.example.env
+++ b/oli.example.env
@@ -34,6 +34,7 @@ EMAIL_FROM_ADDRESS="no-reply@example.edu"
 EMAIL_REPLY_TO=admin@example.edu
 
 # ## Help Desk
+# HELP_PROVIDER=EmailHelp
 # HELP_DESK_EMAIL=help@example.edu
 # FRESHDESK_API_KEY=example_api_key
 # FRESHDESK_API_URL=https://<domain>.freshdesk.com/api/v2/tickets


### PR DESCRIPTION
[MER-624](https://eliterate.atlassian.net/browse/MER-624)

Make Help Provider a configurable and dynamic env variable.

### Release Notes (important)
Ensure `HELP_PROVIDER` env variable is added to each Torus instance with the corresponding value:
- `HELP_PROVIDER=FreshdeskHelp` or `HELP_PROVIDER=EmailHelp` depending on the case.