### PR TITLE
[MER 700] Add Cognito SSO support

### DIFF
--- a/lib/oli/institutions/sso_jwks.ex
+++ b/lib/oli/institutions/sso_jwks.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Institutions.SsoJwk do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "sso_jwks" do
+    field :pem, :string
+    field :typ, :string
+    field :alg, :string
+    field :kid, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(sso_jwk, attrs \\ %{}) do
+    sso_jwk
+    |> cast(attrs, [:pem, :typ, :alg, :kid])
+    |> validate_required([:pem, :typ, :alg, :kid])
+  end
+end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -62,6 +62,12 @@ defmodule Oli.Utils do
     Phoenix.View.render(view, template, Map.put(assigns, :inner_content, content))
   end
 
+  def snake_case_to_friendly(input) when is_atom(input) do
+    input
+    |> Atom.to_string()
+    |> snake_case_to_friendly()
+  end
+
   def snake_case_to_friendly(snake_input) do
     String.split(snake_input, "_")
     |> Enum.map(fn word -> String.capitalize(word) end)

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -1,0 +1,158 @@
+defmodule OliWeb.CognitoController do
+  use OliWeb, :controller
+  import Oli.HTTP
+  import Oli.Utils
+  import Ecto.Changeset
+  require Logger
+
+  alias Oli.Accounts
+  alias Oli.Groups
+  alias Oli.Institutions
+  alias Oli.Institutions.SsoJwk
+
+  @jwks_relative_path "/.well-known/jwks.json"
+
+  def launch(conn, params) do
+    try do
+      with {:ok, valid_params} <- validate_query_params(params),
+           {:ok, %SsoJwk{pem: pem}} <- get_jwk(valid_params.id_token) do
+        jwk = JOSE.JWK.from_pem(pem)
+
+        case JOSE.JWT.verify_strict(jwk, ["RS256"], valid_params.id_token) do
+          {true, %{fields: jwt_fields}, _} ->
+            case Accounts.insert_or_update_lms_user(%{
+                   sub: Map.get(jwt_fields, "sub"),
+                   preferred_username: Map.get(jwt_fields, "cognito:username"),
+                   email: Map.get(jwt_fields, "email"),
+                   can_create_sections: true
+                 }) do
+              {:ok, user} ->
+                community_id = valid_params.community_id
+
+                Groups.create_community_account(%{user_id: user.id, community_id: community_id})
+
+                conn
+                |> use_pow_config(:user)
+                |> Pow.Plug.create(user)
+                |> redirect(
+                  to: Routes.page_delivery_path(conn, :index, valid_params.course_section_id)
+                )
+
+              {:error, %Ecto.Changeset{errors: errors}} ->
+                error_fields =
+                  errors
+                  |> Keyword.keys()
+                  |> Enum.join(", ")
+
+                error_message = error_fields <> " - missing or invalid"
+                Logger.error(error_message)
+
+                redirect_with_error(conn, valid_params, error_message)
+            end
+
+          {false, _, _} ->
+            error_message = "Unable to verify credentials"
+            Logger.error(error_message)
+
+            redirect_with_error(conn, valid_params, error_message)
+        end
+      else
+        {:error, error} ->
+          error_message = snake_case_to_friendly(error)
+
+          Logger.error(error_message)
+
+          redirect_with_error(conn, params, error_message)
+      end
+    rescue
+      e ->
+        %exception_type{} = e
+        error_message = "Unknown error occurred - #{exception_type}"
+        Logger.error("#{uuid()} - #{error_message}")
+
+        redirect_with_error(conn, params, error_message)
+    end
+  end
+
+  defp validate_query_params(params) do
+    data = %{}
+
+    types = %{
+      course_section_id: :string,
+      id_token: :string,
+      error_url: :string,
+      community_id: :string
+    }
+
+    changeset =
+      {data, types}
+      |> cast(params, Map.keys(types))
+      |> validate_required([:course_section_id, :id_token, :error_url, :community_id])
+
+    if changeset.valid? do
+      {:ok, apply_changes(changeset)}
+    else
+      error_fields =
+        changeset.errors
+        |> Keyword.keys()
+        |> Enum.join(", ")
+
+      error_message = error_fields <> " - missing or invalid params"
+
+      {:error, error_message}
+    end
+  end
+
+  defp get_cognito_jwks(issuer) do
+    url = issuer <> @jwks_relative_path
+
+    case http().get(url) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        jwks =
+          body
+          |> Poison.decode!()
+          |> JOSE.JWK.from_map()
+
+        {:ok, jwks}
+
+      {:ok, %HTTPoison.Response{body: body}} ->
+        {:error, "Error retrieving the JWKS - #{body}"}
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, "Error retrieving the JWKS - #{reason}"}
+    end
+  end
+
+  defp get_jwk(id_token) do
+    with {:ok, %{"kid" => kid}} <- Joken.peek_header(id_token),
+         {:ok, %{"iss" => issuer}} <- Joken.peek_claims(id_token),
+         nil <- Institutions.get_jwk_by(%{kid: kid}),
+         {:ok, %JOSE.JWK{keys: {_, keys}}} <- get_cognito_jwks(issuer) do
+      jwk =
+        keys
+        |> Enum.map(&Institutions.build_jwk/1)
+        |> Institutions.insert_bulk_jwks()
+        |> Enum.find(fn %SsoJwk{kid: jwk_kid} -> jwk_kid == kid end)
+
+      {:ok, jwk}
+    else
+      {:error, error} ->
+        {:error, error}
+
+      %SsoJwk{} = jwk ->
+        {:ok, jwk}
+    end
+  end
+
+  defp get_error_url(%{"error_url" => error_url}), do: error_url
+  defp get_error_url(%{error_url: error_url}), do: error_url
+  defp get_error_url(_params), do: "/unauthorized"
+
+  defp redirect_with_error(conn, params, error) do
+    error_url = get_error_url(params)
+
+    conn
+    |> redirect(external: "#{error_url}?error=#{error}")
+    |> halt()
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -848,6 +848,11 @@ defmodule OliWeb.Router do
     live("/:project_id/history/:slug", RevisionHistory)
   end
 
+  # Support for cognito JWT auth currently used by Infiniscope
+  scope "/cognito", OliWeb do
+    get("/launch", CognitoController, :launch)
+  end
+
   # routes only accessible when load testing mode is enabled. These routes exist solely
   # to allow the load testing framework to do things like query for the available open and free
   # sections, to query for all of the pages in an individual section, etc.

--- a/priv/repo/migrations/20220113173021_cognito_sso_jwks_store.exs
+++ b/priv/repo/migrations/20220113173021_cognito_sso_jwks_store.exs
@@ -1,0 +1,14 @@
+defmodule Oli.Repo.Migrations.CognitoSsoJwksStore do
+  use Ecto.Migration
+
+  def change do
+    create table(:sso_jwks) do
+      add :pem, :text
+      add :typ, :string
+      add :alg, :string
+      add :kid, :string
+
+      timestamps(type: :timestamptz)
+    end
+  end
+end

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -1,0 +1,232 @@
+defmodule OliWeb.CognitoControllerTest do
+  use OliWeb.ConnCase
+
+  import ExUnit.CaptureLog
+  import Oli.Factory
+  import Mox
+
+  alias Oli.Accounts
+  alias Oli.Groups
+  alias Oli.Groups.Community
+  alias Oli.Delivery.Sections.Section
+
+  @error_url "https://www.example.com"
+
+  describe "launch" do
+    setup do
+      community = insert(:community, name: "Infiniscope")
+      section = insert(:section, %{slug: "open_section", open_and_free: true})
+      email = build(:user).email
+
+      [community: community, section: section, email: email]
+    end
+
+    test "creates user and adds him as community member", %{
+      conn: conn,
+      community: %Community{id: community_id},
+      section: %Section{slug: slug},
+      email: email
+    } do
+      {id_token, jwk, issuer} = generate_token(email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params = valid_params(community_id, id_token, slug)
+
+      body =
+        conn
+        |> get(cognito_launch_path(conn, params))
+        |> html_response(302)
+
+      assert body =~ "You are being <a href=\"/sections/#{slug}/overview\">redirected</a>"
+
+      new_user = Accounts.get_user_by(%{email: email})
+
+      assert new_user
+      assert new_user.can_create_sections
+      assert Groups.get_community_account_by!(%{user_id: new_user.id, community_id: community_id})
+    end
+
+    test "does not create user when there is a missing param", %{
+      conn: conn,
+      section: %Section{slug: slug},
+      email: email
+    } do
+      params = %{
+        community_id: "some_id",
+        course_section_id: slug,
+        error_url: @error_url
+      }
+
+      error_message = "Id Token - missing or invalid params"
+
+      assert capture_log(fn ->
+               body =
+                 conn
+                 |> get(cognito_launch_path(conn, params))
+                 |> html_response(302)
+
+               assert body =~
+                        "You are being <a href=\"#{@error_url}?error=#{error_message}\">redirected</a>"
+
+               refute Accounts.get_user_by(%{email: email})
+             end) =~ error_message
+    end
+
+    test "does not create user when the id token is malformed", %{
+      conn: conn,
+      section: %Section{slug: slug},
+      email: email
+    } do
+      params = valid_params("some id", "bad_token", slug)
+
+      error_message = "Token Malformed"
+
+      assert capture_log(fn ->
+               body =
+                 conn
+                 |> get(cognito_launch_path(conn, params))
+                 |> html_response(302)
+
+               assert body =~
+                        "You are being <a href=\"#{@error_url}?error=#{error_message}\">redirected</a>"
+
+               refute Accounts.get_user_by(%{email: email})
+             end) =~ error_message
+    end
+
+    test "does not create user when the JWKS endpoint is not working", %{
+      conn: conn,
+      community: %Community{id: community_id},
+      section: %Section{slug: slug},
+      email: email
+    } do
+      {id_token, jwk, issuer} = generate_token(email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :error))
+
+      params = valid_params(community_id, id_token, slug)
+      error_message = "Error retrieving the jwks - jwks not present"
+
+      assert capture_log(fn ->
+               body =
+                 conn
+                 |> get(cognito_launch_path(conn, params))
+                 |> html_response(302)
+
+               assert body =~
+                        "You are being <a href=\"#{@error_url}?error=#{error_message}\">redirected</a>"
+
+               refute Accounts.get_user_by(%{email: email})
+             end) =~ error_message
+    end
+
+    test "does not create user when it fails to verify the id token", %{
+      conn: conn,
+      community: %Community{id: community_id},
+      section: %Section{slug: slug},
+      email: email
+    } do
+      {id_token, jwk, issuer} = generate_token(email, "RS384")
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params = valid_params(community_id, id_token, slug)
+      error_message = "Unable to verify credentials"
+
+      assert capture_log(fn ->
+               body =
+                 conn
+                 |> get(cognito_launch_path(conn, params))
+                 |> html_response(302)
+
+               assert body =~
+                        "You are being <a href=\"#{@error_url}?error=#{error_message}\">redirected</a>"
+
+               refute Accounts.get_user_by(%{email: email})
+             end) =~ error_message
+    end
+
+    defp cognito_launch_path(conn, params), do: Routes.cognito_path(conn, :launch, params)
+
+    defp mock_jwks_endpoint(url, jwk, :ok) do
+      fn ^url ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body:
+             Jason.encode!(%{
+               keys: [
+                 jwk.pem
+                 |> JOSE.JWK.from_pem()
+                 |> JOSE.JWK.to_public()
+                 |> JOSE.JWK.to_map()
+                 |> (fn {_kty, public_jwk} -> public_jwk end).()
+                 |> Map.put("typ", jwk.typ)
+                 |> Map.put("alg", jwk.alg)
+                 |> Map.put("kid", jwk.kid)
+                 |> Map.put("use", "sig")
+               ]
+             })
+         }}
+      end
+    end
+
+    defp mock_jwks_endpoint(url, _jwk, :error) do
+      fn ^url ->
+        {:ok, %HTTPoison.Response{status_code: 404, body: "jwks not present"}}
+      end
+    end
+
+    defp generate_token(email, alg \\ "RS256") do
+      jwk = build(:sso_jwk, alg: alg)
+
+      custom_header = %{"kid" => jwk.kid}
+      signer = Joken.Signer.create(alg, %{"pem" => jwk.pem}, custom_header)
+
+      claims = build_claims(email)
+      issuer = claims["iss"]
+
+      {:ok, claims} =
+        Joken.Config.default_claims()
+        |> Joken.generate_claims(claims)
+
+      {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+
+      {id_token, jwk, issuer}
+    end
+
+    defp build_claims(email) do
+      sub = UUID.uuid4()
+
+      %{
+        "at_hash" => UUID.uuid4(),
+        "sub" => sub,
+        "email_verified" => true,
+        "iss" => "issuer",
+        "cognito:username" => sub,
+        "origin_jti" => UUID.uuid4(),
+        "aud" => UUID.uuid4(),
+        "event_id" => UUID.uuid4(),
+        "token_use" => "id",
+        "auth_time" => 1_642_608_077,
+        "exp" => 1_642_611_677,
+        "iat" => 1_642_608_077,
+        "jti" => UUID.uuid4(),
+        "email" => email
+      }
+    end
+
+    defp valid_params(community_id, id_token, section_slug) do
+      %{
+        "community_id" => community_id,
+        "course_section_id" => section_slug,
+        "id_token" => id_token,
+        "error_url" => @error_url
+      }
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,7 +6,7 @@ defmodule Oli.Factory do
   alias Oli.Delivery.Sections.{Section, SectionsProjectsPublications, SectionResource}
   alias Oli.Delivery.Gating.GatingCondition
   alias Oli.Groups.{Community, CommunityAccount, CommunityInstitution, CommunityVisibility}
-  alias Oli.Institutions.Institution
+  alias Oli.Institutions.{Institution, SsoJwk}
   alias Oli.Publishing.{Publication, PublishedResource}
   alias Oli.Resources.{Resource, Revision}
 
@@ -206,6 +206,17 @@ defmodule Oli.Factory do
       resource: insert(:resource),
       type: :schedule,
       data: %{end_datetime: end_date, start_datetime: start_date}
+    }
+  end
+
+  def sso_jwk_factory() do
+    %{private_key: private_key} = Lti_1p3.KeyGenerator.generate_key_pair()
+
+    %SsoJwk{
+      pem: private_key,
+      typ: "JWT",
+      alg: "RS256",
+      kid: UUID.uuid4()
     }
   end
 end


### PR DESCRIPTION
[MER-700](https://eliterate.atlassian.net/browse/MER-700) (actual story is [MER-339](https://eliterate.atlassian.net/browse/MER-339))

Add Cognito endpoint to Torus in order to complete the SSO flow for Infiniscope users.
It creates the user in the system and adds him as community member of the Infiniscope community (id passed as query param which is not secure but will be fixed in a future PR).