### PR TITLE
[BUGFIX] [MER-762] Fix Internal Server Error in Course Section View

### DIFF
--- a/lib/oli/branding.ex
+++ b/lib/oli/branding.ex
@@ -185,7 +185,7 @@ defmodule Oli.Branding do
   end
 
   defp brand_with_defaults(section) do
-    Map.merge(get_default_brand(), get_most_relevant_brand(section))
+    Map.merge(get_default_brand(), get_most_relevant_brand(section), fn _k, v1, v2 -> v2 || v1 end)
   end
 
   defp get_most_relevant_brand(section) do

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -204,6 +204,8 @@ defmodule Oli.Utils do
   Returns the given url or path ensuring it is absolute. If a relative path is given, then
   the configured base url will be prepended
   """
+  def ensure_absolute_url(nil), do: ""
+
   def ensure_absolute_url(url) do
     if is_url_absolute(url) do
       url

--- a/test/oli/branding_test.exs
+++ b/test/oli/branding_test.exs
@@ -30,6 +30,17 @@ defmodule Oli.BrandingTest do
       brand
     end
 
+    defp default_brand do
+      default_branding = Application.get_env(:oli, :branding)
+
+      %Brand{
+        name: Keyword.get(default_branding, :name),
+        logo: Keyword.get(default_branding, :logo),
+        logo_dark: Keyword.get(default_branding, :logo_dark),
+        favicons: Keyword.get(default_branding, :favicons)
+      }
+    end
+
     test "list_brands/0 returns all brands" do
       brand = brand_fixture()
       assert Branding.list_brands() == [brand]
@@ -197,6 +208,19 @@ defmodule Oli.BrandingTest do
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
       assert Branding.brand_logo_url_dark(section) == "#{Oli.Utils.get_base_url()}/some_logo_dark"
+    end
+
+    @tag capture_log: true
+    test "brand_logo_url_dark returns default brand logo url when section brand logo is nil", %{
+      section: section
+    } do
+      section_brand = brand_fixture(%{logo_dark: nil})
+
+      {:ok, section} =
+        Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      assert Branding.brand_logo_url_dark(section) ==
+               "#{Oli.Utils.get_base_url()}" <> default_brand().logo_dark
     end
 
     @tag capture_log: true

--- a/test/oli/utils_test.exs
+++ b/test/oli/utils_test.exs
@@ -27,8 +27,14 @@ defmodule Oli.UtilsTest do
       assert Utils.ensure_absolute_url("http://already-aboslute") == "http://already-aboslute"
       assert Utils.ensure_absolute_url("https://already-aboslute") == "https://already-aboslute"
 
-      assert Utils.ensure_absolute_url("https://already-aboslute:8080/keeps/path?and=all&params=true") ==
+      assert Utils.ensure_absolute_url(
                "https://already-aboslute:8080/keeps/path?and=all&params=true"
+             ) ==
+               "https://already-aboslute:8080/keeps/path?and=all&params=true"
+    end
+
+    test "returns an empty string when the input url is nil" do
+      assert Utils.ensure_absolute_url(nil) == ""
     end
   end
 end


### PR DESCRIPTION
[MER-762](https://eliterate.atlassian.net/browse/MER-762)

Fix 500 error raised when rendering a Course Section show view, in any of the following cases:
- The brand selected when creating the section has a `nil` `logo_dark`, even though the default brand dark logo is not `nil`.
- Both section `logo_dark` field and default dark logo are `nil`.